### PR TITLE
 🎉 Build(HAT-111) : 지역별 커뮤니티 프로젝트 설정 

### DIFF
--- a/community-app-external-api/build.gradle
+++ b/community-app-external-api/build.gradle
@@ -21,6 +21,11 @@ jar {
 }
 
 dependencies {
+    implementation project(":module-core")
+
+    api project(":community-domain-service")
+    implementation project (":community-domain-rds")
+
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
@@ -28,3 +33,6 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+
+

--- a/community-app-external-api/settings.gradle
+++ b/community-app-external-api/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = 'app-community-external-api'
+
+include "community-domain-service"
+include "community-domain-rds"
+include "community-domain-redis"

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/AppCommunityExternalApiApplication.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/AppCommunityExternalApiApplication.java
@@ -3,11 +3,13 @@ package io.howstheairtoday.appcommunityexternalapi;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+
 @SpringBootApplication
 public class AppCommunityExternalApiApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(AppCommunityExternalApiApplication.class, args);
+
     }
 
 }

--- a/community-domain-rds/build.gradle
+++ b/community-domain-rds/build.gradle
@@ -28,9 +28,18 @@ jar {
 
 dependencies {
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    //JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
+
+
 }
 
 tasks.named('test') {

--- a/community-domain-rds/settings.gradle
+++ b/community-domain-rds/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'community-domain-rds'
+

--- a/community-domain-rds/src/main/resources/application.yaml
+++ b/community-domain-rds/src/main/resources/application.yaml
@@ -1,1 +1,20 @@
 
+# 정훈
+spring:
+  config:
+    activate:
+      on-profile: "kjh"
+  datasource:
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://localhost:3306/hat_local_community
+    username: root
+    password: 12341234
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+---
+


### PR DESCRIPTION
## Motivation:
- community  의존관계 설정

## Modifications:
- community-api 
  - settings.gradle
 ```
  include "community-domain-service"
  include "community-domain-rds"
  include "community-domain-redis"
  ```
  
  ```
  dependencies {
      implementation project(":module-core")
  
      api project(":community-domain-service") 
      implementation project (":community-domain-rds")
  }
 ```
 - 나중을 위해서 service 는  연결만 해놓은상태 
 - module-core는  인증인가 가 확인된 유저만 게시물을 사용할수있기때문에 연결했습니다.


- community-rds
    ```
    dependencies {
        //JPA
        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
        implementation 'org.springframework.boot:spring-boot-starter-jdbc'
        runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
    }
   ```
- application.yml
  - 주형이도 같은 모듈을 사용하기때문에 on-profile 에서 설정을 걸고 시작합니다. 
  ```
  # 정훈
  spring:
    config:
      activate:
        on-profile: "kjh"
  ----
  ex)
  # 주형 
    spring:
      config:
        activate:
          on-profile: "Joo"

   ```


## Result:
-  디비 접속 성공여부는 jira 명시 해놓은상태고 community 작업을 하시는분들은  
- ** Edit Configuration 클릭후 -> CommunityDomainRdsApplication 클릭후  active profiles 부분에 yml에 적었던 on-profile부분을 적고 시작합니다.** 