### PR TITLE
🚑 fix(HAT-141): QueryDSL 설정 변경

### DIFF
--- a/air-quality-domain-rds/build.gradle
+++ b/air-quality-domain-rds/build.gradle
@@ -8,8 +8,6 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.4'
     id 'io.spring.dependency-management' version '1.1.0'
-    // QueryDSL
-    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'io.howstheairtoday'
@@ -38,36 +36,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
     // QueryDSL
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
-}
-
-// ============= QueryDSL =============
-def querydslDir = "$buildDir/generated/querydsl"
-
-querydsl {
-    jpa = true
-    querydslSourcesDir = querydslDir
-}
-
-sourceSets {
-    main.java.srcDir querydslDir
-}
-
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-    querydsl.extendsFrom compileClasspath
-}
-
-compileQuerydsl {
-    options.annotationProcessorPath = configurations.querydsl
 }

--- a/community-domain-rds/build.gradle
+++ b/community-domain-rds/build.gradle
@@ -8,8 +8,6 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.4'
     id 'io.spring.dependency-management' version '1.1.0'
-    // QueryDSL
-    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'io.howstheairtoday'
@@ -38,36 +36,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
     // QueryDSL
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
-}
-
-// ============= QueryDSL =============
-def querydslDir = "$buildDir/generated/querydsl"
-
-querydsl {
-    jpa = true
-    querydslSourcesDir = querydslDir
-}
-
-sourceSets {
-    main.java.srcDir querydslDir
-}
-
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-    querydsl.extendsFrom compileClasspath
-}
-
-compileQuerydsl {
-    options.annotationProcessorPath = configurations.querydsl
 }

--- a/member-domain-rds/build.gradle
+++ b/member-domain-rds/build.gradle
@@ -8,13 +8,17 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.4'
     id 'io.spring.dependency-management' version '1.1.0'
-    // QueryDSL
-    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'io.howstheairtoday'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
 
 repositories {
     mavenCentral()
@@ -32,9 +36,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
     // QueryDSL
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
@@ -42,27 +47,3 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
-
-// ============= QueryDSL =============
-def querydslDir = "$buildDir/generated/querydsl"
-
-querydsl {
-    jpa = true
-    querydslSourcesDir = querydslDir
-}
-
-sourceSets {
-    main.java.srcDir querydslDir
-}
-
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-    querydsl.extendsFrom compileClasspath
-}
-
-compileQuerydsl {
-    options.annotationProcessorPath = configurations.querydsl
-}
-


### PR DESCRIPTION
## Motivation:

- QueryDSL 경로 지정으로 인해 `Q클래스`를 생성하지 못하는 이슈 발생

```bash
> Attempt to recreate a file for type io.howstheairtoday.airqualitydomainrds.entity.QBaseTimeEntity
```

## Modifications:

- QueryDSL 경로 지정 스크립트 제거
  - 기존 경로
    - `build/generated/querydsl`
  - 수정 경로
    - `build/generated/` 
- plugin 제거

## Result:

![image](https://user-images.githubusercontent.com/70932170/227188792-e3fc29a6-1a19-4fd6-abb8-1975bc26ea99.png)
