### PR TITLE
👷 ci(HAT-152): 구글 자바 포맷 비활성화

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -48,6 +48,7 @@ jobs:
         env:
           LINTER_RULES_PATH: .github/workflows/linters
           JAVA_FILE_NAME: naver-checkstyle-rules.xml
+          VALIDATE_GOOGLE_JAVA_FORMAT: false
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.HAT_BE_ACTIONS }}


### PR DESCRIPTION
## Motivation:

- [Super-Linter](https://github.com/marketplace/actions/super-linter#using-your-own-rules-files)의 Java 코드 분석 규칙으로 [Naver Convention](https://naver.github.io/hackday-conventions-java/#_intellij)을 새롭게 추가했지만, [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html#s5.1-identifier-names)와 함께 코드 검사를 수행하여 변경 필요

## Modifications:

- `linter.yaml` 스크립트에 `VALIDATE_GOOGLE_JAVA_FORMAT: false` 옵션 추가

## Result:

- 코드 분석 시 구글 자바 포맷 비활성화