### PR TITLE
✨ feat(HAT-78): 대기질 실시간 측정정보 가공

### DIFF
--- a/air-quality-app-batch/src/main/java/io/howstheairtoday/service/AirQualityRealTimeService.java
+++ b/air-quality-app-batch/src/main/java/io/howstheairtoday/service/AirQualityRealTimeService.java
@@ -102,9 +102,10 @@ public class AirQualityRealTimeService {
                 .dataTime(dateTime)
                 .build();
 
-            // KhaiValue를 기준으로 정렬
             currentDustResponseDTOList.add(currentDustResponseDTO);
         }
+
+        // KhaiValue를 기준으로 정렬
         currentDustResponseDTOList.sort(Comparator.comparing(CurrentDustResponseDTO::getKhaiValue));
         return currentDustResponseDTOList;
     }


### PR DESCRIPTION
## Motivation:

- 대기질 실시간 측정 정보 가공

## Modifications:

- 호출한 API JSON 데이터를 파싱.
- 파싱한 데이터들이 들어 있는 배열을 KhaiValue 값을 기준으로 정렬

## Result:

- Service 및 Test에서 한 일은 두 가지임.
  - 데이터 파싱
  - 배열 값을 정렬
- 시도별 대기질 측정정보 데이터를 데이터베이스에 저장하기 이전 단계