### PR TITLE
✨ feat(HAT-84): 회원 정보 생성 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ project('member-domain-service') {
 project('member-domain-rds') {
     dependencies {
         implementation project(':module-common')
+        implementation project(':module-core')
     }
 }
 

--- a/member-app-external-api/src/main/java/io/howstheairtoday/MemberAppExternalApiApplication.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/MemberAppExternalApiApplication.java
@@ -2,8 +2,10 @@ package io.howstheairtoday;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class MemberAppExternalApiApplication {
 
     public static void main(String[] args) {

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/common/ApiResponse.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/common/ApiResponse.java
@@ -1,0 +1,58 @@
+package io.howstheairtoday.memberappexternalapi.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * API 응답 객체.
+ *
+ * @param <T> 데이터 타입.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Data
+@Builder
+public class ApiResponse<T> {
+
+    /** 응답 메시지. */
+    private String msg;
+
+    /** 응답 코드. */
+    private Integer statusCode;
+
+    /** 데이터. */
+    private T data;
+
+    /**
+     * 응답 객체 생성.
+     *
+     * @param <T> 데이터 타입.
+     * @param statusCode 응답 코드.
+     * @param msg 응답 메시지.
+     * @return ApiResponse 객체.
+     */
+    public static <T> ApiResponse<T> res(final Integer statusCode, final String msg) {
+        return ApiResponse.<T>builder()
+            .statusCode(statusCode)
+            .msg(msg)
+            .build();
+    }
+
+    /**
+     * 응답 객체 생성.
+     *
+     * @param <T> 데이터 타입.
+     * @param statusCode 응답 코드.
+     * @param msg 응답 메시지.
+     * @param data 데이터.
+     * @return ApiResponse 객체.
+     */
+    public static <T> ApiResponse<T> res(final Integer statusCode, final String msg, final T data) {
+        return ApiResponse.<T>builder()
+            .statusCode(statusCode)
+            .msg(msg)
+            .data(data)
+            .build();
+    }
+}

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/controller/MemberController.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/controller/MemberController.java
@@ -1,0 +1,35 @@
+package io.howstheairtoday.memberappexternalapi.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.howstheairtoday.memberappexternalapi.common.ApiResponse;
+import io.howstheairtoday.memberappexternalapi.service.ExternalMemberService;
+import io.howstheairtoday.memberappexternalapi.service.dto.request.MemberRequestDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class MemberController {
+
+    private final ExternalMemberService externalMemberService;
+
+    @PostMapping("/account/signup")
+    public ResponseEntity<ApiResponse<UUID>> createMember(@Valid @RequestBody final MemberRequestDTO.SaveMemberRequestDto requestDTO) {
+
+        try {
+            UUID memberId = externalMemberService.createMember(requestDTO);
+            return ResponseEntity.ok(ApiResponse.res(HttpStatus.OK.value(), "회원가입에 성공했습니다.", memberId));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(ApiResponse.res(HttpStatus.BAD_REQUEST.value(), "회원가입에 실패했습니다."));
+        }
+    }
+}

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/ExternalMemberService.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/ExternalMemberService.java
@@ -1,0 +1,38 @@
+package io.howstheairtoday.memberappexternalapi.service;
+
+import java.util.UUID;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import io.howstheairtoday.memberappexternalapi.service.dto.request.MemberRequestDTO;
+import io.howstheairtoday.memberdomainrds.entity.LoginRole;
+import io.howstheairtoday.memberdomainrds.entity.LoginType;
+import io.howstheairtoday.memberdomainrds.entity.Member;
+import io.howstheairtoday.memberdomainrds.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+
+@Service
+@RequiredArgsConstructor
+public class ExternalMemberService {
+
+    private final MemberRepository memberRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    public UUID createMember(MemberRequestDTO.SaveMemberRequestDto requestDTO) throws Exception {
+        Member member = Member.builder()
+            .loginId(requestDTO.getLoginId())
+            .loginPassword(requestDTO.getLoginPassword())
+            .email(requestDTO.getEmail())
+            .nickname(requestDTO.getNickname())
+            .memberProfileImage("default.jpg")
+            .loginType(LoginType.LOCAL)
+            .loginRole(LoginRole.ROLE_USER)
+            .build();
+        member.encodePassword(passwordEncoder);
+        Member savedMember = memberRepository.save(member);
+        return savedMember.getMemberId();
+    }
+}

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/MemberDetailsService.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/MemberDetailsService.java
@@ -9,7 +9,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import io.howstheairtoday.memberappexternalapi.service.dto.MemberLoginRequestDTO;
+import io.howstheairtoday.memberappexternalapi.service.dto.request.MemberLoginRequestDTO;
 import io.howstheairtoday.memberdomainrds.entity.Member;
 import io.howstheairtoday.memberdomainrds.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/MemberLoginRequestDTO.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/MemberLoginRequestDTO.java
@@ -1,4 +1,4 @@
-package io.howstheairtoday.memberappexternalapi.service.dto;
+package io.howstheairtoday.memberappexternalapi.service.dto.request;
 
 import java.util.Collection;
 

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/MemberRequestDTO.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/MemberRequestDTO.java
@@ -12,10 +12,10 @@ import lombok.NoArgsConstructor;
 
 public class MemberRequestDTO {
 
-    @AllArgsConstructor
     @NoArgsConstructor
-    @Getter
+    @AllArgsConstructor
     @Builder
+    @Getter
     public static class SaveMemberRequestDto {
 
         /**

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/MemberRequestDTO.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/MemberRequestDTO.java
@@ -1,0 +1,48 @@
+package io.howstheairtoday.memberappexternalapi.service.dto.request;
+
+import io.howstheairtoday.memberdomainrds.entity.LoginRole;
+import io.howstheairtoday.memberdomainrds.entity.LoginType;
+import io.howstheairtoday.memberdomainrds.entity.Member;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MemberRequestDTO {
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Builder
+    public static class SaveMemberRequestDto {
+
+        /**
+         * 회원가입시 필요한 내용
+         */
+        @NotBlank(message = "아이디를 입력해 주세요.")
+        private String loginId;
+
+        @NotEmpty(message = "비밀번호를 입력해 주세요.")
+        private String loginPassword;
+
+        @NotBlank(message = "인증 가능한 이메일을 입력해 주세요.")
+        private String email;
+
+        @NotBlank(message = "사용하실 닉네임을 입력해 주세요.")
+        private String nickname;
+
+        public Member toEntity() {
+            return Member.builder()
+                .loginId(loginId)
+                .loginPassword(loginPassword)
+                .email(email)
+                .nickname(nickname)
+                .memberProfileImage("default.jpg")
+                .loginType(LoginType.LOCAL)
+                .loginRole(LoginRole.ROLE_USER)
+                .build();
+        }
+    }
+}

--- a/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/service/ExternalMemberServiceTest.java
+++ b/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/service/ExternalMemberServiceTest.java
@@ -1,0 +1,57 @@
+package io.howstheairtoday.memberappexternalapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import io.howstheairtoday.memberappexternalapi.service.dto.request.MemberRequestDTO;
+import io.howstheairtoday.memberdomainrds.entity.LoginRole;
+import io.howstheairtoday.memberdomainrds.entity.LoginType;
+import io.howstheairtoday.memberdomainrds.entity.Member;
+import io.howstheairtoday.memberdomainrds.repository.MemberRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class ExternalMemberServiceTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ExternalMemberService externalMemberService;
+
+    @DisplayName("회원 생성 기능 - 기본")
+    @Test
+    void createMemberTest() throws Exception {
+        // given
+        MemberRequestDTO.SaveMemberRequestDto requestDTO = MemberRequestDTO.SaveMemberRequestDto.builder()
+            .loginId("testId")
+            .loginPassword("test123")
+            .email("test@test.com")
+            .nickname("testNick")
+            .build();
+
+        // when
+        UUID memberId = externalMemberService.createMember(requestDTO);
+
+        // then
+        Member savedMember = memberRepository.findById(memberId).orElseThrow(Exception::new);
+        assertThat(savedMember.getLoginId()).isEqualTo(requestDTO.getLoginId());
+        assertThat(savedMember.getEmail()).isEqualTo(requestDTO.getEmail());
+        assertThat(savedMember.getNickname()).isEqualTo(requestDTO.getNickname());
+        assertThat(savedMember.getMemberProfileImage()).isEqualTo("default.jpg");
+        assertThat(savedMember.getLoginType()).isEqualTo(LoginType.LOCAL);
+        assertThat(savedMember.getLoginRole()).isEqualTo(LoginRole.ROLE_USER);
+        assertThat(passwordEncoder.matches(requestDTO.getLoginPassword(), savedMember.getLoginPassword())).isTrue();
+    }
+}

--- a/member-domain-rds/src/main/generated/io/howstheairtoday/memberdomainrds/entity/QBaseTimeEntity.java
+++ b/member-domain-rds/src/main/generated/io/howstheairtoday/memberdomainrds/entity/QBaseTimeEntity.java
@@ -1,0 +1,41 @@
+package io.howstheairtoday.memberdomainrds.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseTimeEntity is a Querydsl query type for BaseTimeEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseTimeEntity extends EntityPathBase<BaseTimeEntity> {
+
+    private static final long serialVersionUID = 286568496L;
+
+    public static final QBaseTimeEntity baseTimeEntity = new QBaseTimeEntity("baseTimeEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = createDateTime("deletedAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QBaseTimeEntity(String variable) {
+        super(BaseTimeEntity.class, forVariable(variable));
+    }
+
+    public QBaseTimeEntity(Path<? extends BaseTimeEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseTimeEntity(PathMetadata metadata) {
+        super(BaseTimeEntity.class, metadata);
+    }
+
+}
+

--- a/member-domain-rds/src/main/generated/io/howstheairtoday/memberdomainrds/entity/QMember.java
+++ b/member-domain-rds/src/main/generated/io/howstheairtoday/memberdomainrds/entity/QMember.java
@@ -1,0 +1,64 @@
+package io.howstheairtoday.memberdomainrds.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = -413420791L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final QBaseTimeEntity _super = new QBaseTimeEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = _super.deletedAt;
+
+    public final StringPath email = createString("email");
+
+    public final StringPath loginId = createString("loginId");
+
+    public final StringPath loginPassword = createString("loginPassword");
+
+    public final EnumPath<LoginRole> loginRole = createEnum("loginRole", LoginRole.class);
+
+    public final EnumPath<LoginType> loginType = createEnum("loginType", LoginType.class);
+
+    public final ComparablePath<java.util.UUID> memberId = createComparable("memberId", java.util.UUID.class);
+
+    public final StringPath memberProfileImage = createString("memberProfileImage");
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath refreshToken = createString("refreshToken");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/member-domain-rds/src/main/java/io/howstheairtoday/memberdomainrds/entity/Member.java
+++ b/member-domain-rds/src/main/java/io/howstheairtoday/memberdomainrds/entity/Member.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -55,6 +56,10 @@ public class Member extends BaseTimeEntity {
 
     @Column(length = 255)
     private String refreshToken;
+
+    public void encodePassword(PasswordEncoder passwordEncoder) {
+        this.loginPassword = passwordEncoder.encode(loginPassword);
+    }
 
     @Builder
     public Member(String loginId, String loginPassword, String email, String nickname, String memberProfileImage,


### PR DESCRIPTION
## Motivation:

- 회원 가입 서비스 - 기본

## Modifications:

- 회원 가입시 필요한 기본적인 RequestDTO, Service, Controller 클래스를 작성
- JWT Token 및 Spring Security 설정에 테스트를 위해 기본적인 값들로 회원 가입 서비스 로직을 완성 하였음.
    - 이메일 인증 기능(X)

## Result:

- 회원가입시 필요한 정보
    - ID - loginId
    - PW - loginPassword (암호화)
    - email - 이메일 인증은 현재 구현 하지 않음
    - nickname
- 기능은 생성만을 테스트한 것임. Spring Security, JWT를 통한 Refresh Token과 Access Token을 완료하면 기능을 보완할 예정
![image](https://user-images.githubusercontent.com/117193889/229174761-b295cd99-c4a5-4f74-8417-0ab1d172c044.png)
![image](https://user-images.githubusercontent.com/117193889/229174785-903adab1-39e8-43db-820f-c9ec25dbde25.png)
