### PR TITLE
✨ feat(HAT-56): 게시물 댓글 삭제기능

### DIFF
--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/CommentController.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/CommentController.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,6 +51,18 @@ public class CommentController {
         return ApiResponse.<Object>builder()
             .statusCode(HttpStatus.CREATED.value())
             .msg("수정 성공했습니다.")
+            .build();
+    }
+
+    //게시물 댓글 삭제
+    @DeleteMapping("/{postId}/comments/{commentId}")
+    public ApiResponse<Object> deleteComment(@PathVariable("commentId") UUID commentId) {
+
+        commentService.deleteComment(commentId);
+
+        return ApiResponse.<Object>builder()
+            .statusCode(HttpStatus.CREATED.value())
+            .msg("삭제 성공했습니다.")
             .build();
     }
 }

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/CommentService.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/CommentService.java
@@ -1,5 +1,6 @@
 package io.howstheairtoday.appcommunityexternalapi.service;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import io.howstheairtoday.appcommunityexternalapi.service.dto.request.CommentRequestDTO;
 import io.howstheairtoday.communitydomainrds.entity.Comment;
+import io.howstheairtoday.communitydomainrds.repository.CommentRepository;
 import io.howstheairtoday.communitydomainrds.service.DomainCommunityService;
 import lombok.RequiredArgsConstructor;
 
@@ -44,6 +46,19 @@ public class CommentService {
         }
 
         return updatedComment;
+    }
+
+    //게시물 댓글 삭제 처리 (softDelete)
+    public Comment deleteComment(UUID commentId) {
+
+        Optional<Comment> comment = domainCommunityService.findCommentId(commentId);
+
+        Comment deletedComment = comment.get();
+        deletedComment.deletedAt(LocalDateTime.now());
+
+        domainCommunityService.saveComment(deletedComment);
+
+        return deletedComment;
     }
 
 }

--- a/community-app-external-api/src/test/java/io/howstheairtoday/appcommunityexternalapi/controller/CommentControllerTest.java
+++ b/community-app-external-api/src/test/java/io/howstheairtoday/appcommunityexternalapi/controller/CommentControllerTest.java
@@ -81,4 +81,17 @@ class CommentControllerTest {
         resultActions.andDo(print());
     }
 
+    @DisplayName("댓글 삭제 컨트롤러 테스트")
+    @Test
+    void deletedComment() throws Exception{
+
+        //when
+        ResultActions resultActions = mockMvc.perform(delete("/api/v1/post/"+ postId +"/comments/{commentId}", commentId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDTO)));
+
+        // Then
+        resultActions.andDo(print());
+    }
+
 }

--- a/community-app-external-api/src/test/java/io/howstheairtoday/appcommunityexternalapi/service/CommentServiceTest.java
+++ b/community-app-external-api/src/test/java/io/howstheairtoday/appcommunityexternalapi/service/CommentServiceTest.java
@@ -65,4 +65,25 @@ public class CommentServiceTest {
         // then
         assertThat(updatedComment.getContent()).isEqualTo("수정된 댓글");
     }
+
+    @DisplayName("댓글 삭제")
+    @Test
+    void deletedComment() {
+
+        // given
+        UUID postId = UUID.randomUUID();
+
+        CommentRequestDTO commentRequestDTO = CommentRequestDTO.builder()
+            .content("테스트 댓글중")
+            .memberId(UUID.randomUUID())
+            .build();
+
+        Comment savedComment = commentService.createComment(postId, commentRequestDTO);
+
+        // when
+        Comment updatedComment = commentService.deleteComment(savedComment.getCommentId());
+
+        // then
+        assertNotNull(updatedComment.getDeletedAt());
+    }
 }

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/common/BaseTimeEntity.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/common/BaseTimeEntity.java
@@ -28,4 +28,9 @@ public class BaseTimeEntity {
     @Column(name = "deleted_at")
     @Setter
     private LocalDateTime deletedAt;
+
+    // soft delete 메소드
+    public void deletedAt(LocalDateTime deletedAt){
+        this.deletedAt = deletedAt;
+    }
 }


### PR DESCRIPTION
## Motivation:

- 게시물 댓글 삭제

## Modifications:

- 댓글 삭제 service 로직 구현
  - service 테스트 완료
  
- 댓글 삭제 controller 구현
  - controller 테스트 완료

## Result:

- Postman 테스트
![image](https://user-images.githubusercontent.com/54580802/230750390-d8408a93-5e56-4bb9-95e1-eba179ec8b50.png)

- 데이터베이스
![image](https://user-images.githubusercontent.com/54580802/230750408-f3e33cda-cb2e-4a3b-8bad-9f78bca3bf25.png)
