### PR TITLE
✨ feat(HAT-97): 회원 정보 수정

### DIFF
--- a/member-app-external-api/src/main/java/io/howstheairtoday/MemberAppExternalApiApplication.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/MemberAppExternalApiApplication.java
@@ -11,5 +11,4 @@ public class MemberAppExternalApiApplication {
     public static void main(String[] args) {
         SpringApplication.run(MemberAppExternalApiApplication.class, args);
     }
-
 }

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/common/ApiResponse.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/common/ApiResponse.java
@@ -55,4 +55,8 @@ public class ApiResponse<T> {
             .data(data)
             .build();
     }
+
+    public static <T> ApiResponse<T> error(int status, String message) {
+        return new ApiResponse<>(status, message, null);
+    }
 }

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/common/MemberExceptionHandler.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/common/MemberExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import io.howstheairtoday.memberappexternalapi.exception.ConflictException;
 import io.howstheairtoday.memberappexternalapi.exception.DuplicationIdException;
 import io.howstheairtoday.memberappexternalapi.exception.DuplicationNicknameException;
+import io.howstheairtoday.memberappexternalapi.exception.NotFoundException;
 import io.howstheairtoday.memberappexternalapi.exception.PasswordNotMatchedException;
 
 @ControllerAdvice
@@ -35,5 +36,11 @@ public class MemberExceptionHandler {
     public ResponseEntity<ApiResponse<?>> ConflictException(ConflictException e) {
         ApiResponse<?> apiResponse = ApiResponse.res(HttpStatus.BAD_REQUEST.value(), e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(apiResponse);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ApiResponse<?>> NotFoundException(NotFoundException e) {
+        ApiResponse<?> apiResponse = ApiResponse.res(HttpStatus.BAD_REQUEST.value(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(apiResponse);
     }
 }

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/common/MemberExceptionHandler.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/common/MemberExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import io.howstheairtoday.memberappexternalapi.exception.ConflictException;
 import io.howstheairtoday.memberappexternalapi.exception.DuplicationIdException;
 import io.howstheairtoday.memberappexternalapi.exception.DuplicationNicknameException;
 import io.howstheairtoday.memberappexternalapi.exception.PasswordNotMatchedException;
@@ -26,6 +27,12 @@ public class MemberExceptionHandler {
 
     @ExceptionHandler(PasswordNotMatchedException.class)
     public ResponseEntity<ApiResponse<?>> handlePasswordNotMatchedException(PasswordNotMatchedException e) {
+        ApiResponse<?> apiResponse = ApiResponse.res(HttpStatus.BAD_REQUEST.value(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(apiResponse);
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ApiResponse<?>> ConflictException(ConflictException e) {
         ApiResponse<?> apiResponse = ApiResponse.res(HttpStatus.BAD_REQUEST.value(), e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(apiResponse);
     }

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/controller/AuthController.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/controller/AuthController.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.howstheairtoday.memberappexternalapi.common.ApiResponse;
 import io.howstheairtoday.memberappexternalapi.service.AuthService;
+import io.howstheairtoday.memberappexternalapi.service.dto.request.ModifyNicknameRequestDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.SignUpRequestDTO;
 import io.howstheairtoday.memberappexternalapi.service.dto.response.ProfileResponseDto;
 import jakarta.validation.Valid;
@@ -46,6 +48,19 @@ public class AuthController {
             .statusCode(HttpStatus.OK.value())
             .msg("success")
             .data(responseDto)
+            .build();
+    }
+
+    /**
+     * 회원 정보 수정 - 마이페이지
+     */
+    // 닉네임 수정
+    @PatchMapping("/nickname")
+    public ApiResponse<Object> modifyNickname(@Valid @RequestBody final ModifyNicknameRequestDto request) {
+        authService.modifyNickname(request);
+        return ApiResponse.<Object>builder()
+            .statusCode(HttpStatus.OK.value())
+            .msg("닉네임 수정이 완료 되었습니다.")
             .build();
     }
 }

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/controller/AuthController.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/controller/AuthController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.howstheairtoday.memberappexternalapi.common.ApiResponse;
 import io.howstheairtoday.memberappexternalapi.service.AuthService;
+import io.howstheairtoday.memberappexternalapi.service.dto.request.ChangePasswordRequestDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.ModifyNicknameRequestDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.SignUpRequestDTO;
 import io.howstheairtoday.memberappexternalapi.service.dto.response.ProfileResponseDto;
@@ -52,15 +53,26 @@ public class AuthController {
     }
 
     /**
-     * 회원 정보 수정 - 마이페이지
+     * 회원 닉네임 수정
      */
-    // 닉네임 수정
     @PatchMapping("/nickname")
     public ApiResponse<Object> modifyNickname(@Valid @RequestBody final ModifyNicknameRequestDto request) {
         authService.modifyNickname(request);
         return ApiResponse.<Object>builder()
             .statusCode(HttpStatus.OK.value())
             .msg("닉네임 수정이 완료 되었습니다.")
+            .build();
+    }
+
+    /**
+     * 회원 비밀번호 변경
+     */
+    @PatchMapping("/password")
+    public ApiResponse<Object> changePassword(@Valid @RequestBody final ChangePasswordRequestDto request) {
+        authService.changePassword(request);
+        return ApiResponse.<Object>builder()
+            .statusCode(HttpStatus.OK.value())
+            .msg("비밀번호 변경이 완료 되었습니다.")
             .build();
     }
 }

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/controller/AuthController.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/controller/AuthController.java
@@ -15,6 +15,7 @@ import io.howstheairtoday.memberappexternalapi.common.ApiResponse;
 import io.howstheairtoday.memberappexternalapi.service.AuthService;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.ChangePasswordRequestDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.ModifyNicknameRequestDto;
+import io.howstheairtoday.memberappexternalapi.service.dto.request.ModifyProfileImageRequestDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.SignUpRequestDTO;
 import io.howstheairtoday.memberappexternalapi.service.dto.response.ProfileResponseDto;
 import jakarta.validation.Valid;
@@ -73,6 +74,18 @@ public class AuthController {
         return ApiResponse.<Object>builder()
             .statusCode(HttpStatus.OK.value())
             .msg("비밀번호 변경이 완료 되었습니다.")
+            .build();
+    }
+
+    /**
+     * 프로필 이미지 변경
+     */
+    @PatchMapping("/profileimg")
+    public ApiResponse<Object> modifyProfileImg(@Valid @RequestBody final ModifyProfileImageRequestDto request) {
+        authService.modifyProfileImg(request);
+        return ApiResponse.<Object>builder()
+            .statusCode(HttpStatus.OK.value())
+            .msg("이미지 변경이 완료 되었습니다.")
             .build();
     }
 }

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/exception/ConflictException.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/exception/ConflictException.java
@@ -1,0 +1,12 @@
+package io.howstheairtoday.memberappexternalapi.exception;
+
+public class ConflictException extends RuntimeException {
+
+    public ConflictException(String message) {
+        super(message);
+    }
+
+    public ConflictException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/exception/NotFoundException.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package io.howstheairtoday.memberappexternalapi.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/AuthService.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/AuthService.java
@@ -18,9 +18,11 @@ import io.howstheairtoday.memberappexternalapi.exception.NotFoundException;
 import io.howstheairtoday.memberappexternalapi.exception.PasswordNotMatchedException;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.ChangePasswordRequestDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.ModifyNicknameRequestDto;
+import io.howstheairtoday.memberappexternalapi.service.dto.request.ModifyProfileImageRequestDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.SignUpRequestDTO;
 import io.howstheairtoday.memberappexternalapi.service.dto.response.ChangePasswordResponseDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.response.ModifyNicknameResponseDto;
+import io.howstheairtoday.memberappexternalapi.service.dto.response.ProfileImageResponseDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.response.ProfileResponseDto;
 import io.howstheairtoday.memberdomainrds.entity.LoginRole;
 import io.howstheairtoday.memberdomainrds.entity.LoginType;
@@ -135,4 +137,22 @@ public class AuthService {
             .build();
         return ApiResponse.res(HttpStatus.OK.value(), "비밀번호 변경이 완료되었습니다.", result);
     }
+
+    /**
+     * 회원 프로필 이미지 수정
+     */
+    @Transactional
+    public ApiResponse<?> modifyProfileImg(ModifyProfileImageRequestDto request) {
+
+        Member member = memberRepository.findByMemberId(request.getMemberId())
+            .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자입니다."));
+
+        member.modifyProfileImage(request.getMemberProfileImage());
+        ProfileImageResponseDto response = ProfileImageResponseDto.builder()
+            .memberId(member.getMemberId())
+            .memberProfileImage(member.getMemberProfileImage())
+            .build();
+        return ApiResponse.res(HttpStatus.OK.value(), "이미지 변경이 완료 되었습니다.", response);
+    }
+
 }

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/AuthService.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/AuthService.java
@@ -7,13 +7,22 @@ import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import io.howstheairtoday.memberappexternalapi.common.ApiResponse;
 import io.howstheairtoday.memberappexternalapi.common.MemberExceptionHandler;
+import io.howstheairtoday.memberappexternalapi.exception.ConflictException;
 import io.howstheairtoday.memberappexternalapi.exception.DuplicationIdException;
 import io.howstheairtoday.memberappexternalapi.exception.DuplicationNicknameException;
+import io.howstheairtoday.memberappexternalapi.exception.NotFoundException;
 import io.howstheairtoday.memberappexternalapi.exception.PasswordNotMatchedException;
+import io.howstheairtoday.memberappexternalapi.service.dto.request.ChangePasswordRequestDto;
+import io.howstheairtoday.memberappexternalapi.service.dto.request.ModifyNicknameRequestDto;
+import io.howstheairtoday.memberappexternalapi.service.dto.request.ModifyProfileImageRequestDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.SignUpRequestDTO;
+import io.howstheairtoday.memberappexternalapi.service.dto.response.MemberIdResponseDto;
+import io.howstheairtoday.memberappexternalapi.service.dto.response.ModifyNicknameResponseDto;
+import io.howstheairtoday.memberappexternalapi.service.dto.response.ProfileImageResponseDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.response.ProfileResponseDto;
 import io.howstheairtoday.memberdomainrds.entity.LoginRole;
 import io.howstheairtoday.memberdomainrds.entity.LoginType;
@@ -31,7 +40,6 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final MemberExceptionHandler memberExceptionHandler;
-
 
     /**
      * 회원가입
@@ -81,5 +89,26 @@ public class AuthService {
         Optional<Member> result = memberRepository.findByMemberId(memberId);
         Member member = result.orElseThrow(() -> new IllegalArgumentException("해당하는 회원이 존재하지 않습니다."));
         return modelMapper.map(member, ProfileResponseDto.class);
+    }
+
+    /**
+     * 회원 정보 수정 - 마이페이지
+     */
+    @Transactional
+    public ApiResponse<?> modifyNickname(ModifyNicknameRequestDto request) {
+
+        Member member = memberRepository.findByMemberId(request.getMemberId())
+            .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자입니다."));
+
+        if (memberRepository.existsByNickname(request.getNickname())) {
+            throw new ConflictException("이미 사용 중인 닉네임입니다.");
+        }
+
+        member.modifiyNickname(request.getNickname());
+        ModifyNicknameResponseDto response = ModifyNicknameResponseDto.builder()
+            .memberId(member.getMemberId())
+            .nickname(member.getNickname())
+            .build();
+        return ApiResponse.res(HttpStatus.OK.value(), "닉네임 변경이 완료 되었습니다.", response);
     }
 }

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/ChangePasswordRequestDto.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/ChangePasswordRequestDto.java
@@ -1,0 +1,17 @@
+package io.howstheairtoday.memberappexternalapi.service.dto.request;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChangePasswordRequestDto {
+
+    private UUID memberId;
+    private String loginPassword;
+    private String loginPasswordCheck;
+}

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/ModifyNicknameRequestDto.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/ModifyNicknameRequestDto.java
@@ -1,0 +1,16 @@
+package io.howstheairtoday.memberappexternalapi.service.dto.request;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ModifyNicknameRequestDto {
+
+    private UUID memberId;
+    private String nickname;
+}

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/ModifyProfileImageRequestDto.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/ModifyProfileImageRequestDto.java
@@ -1,0 +1,17 @@
+package io.howstheairtoday.memberappexternalapi.service.dto.request;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ModifyProfileImageRequestDto {
+
+    private UUID memberId;
+    private String memberProfileImage;
+}

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/response/ChangePasswordResponseDto.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/response/ChangePasswordResponseDto.java
@@ -6,12 +6,14 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class MemberIdResponseDto {
+public class ChangePasswordResponseDto {
 
     private final UUID memberId;
+    private final String loginPassword;
 
     @Builder
-    public MemberIdResponseDto(UUID memberId) {
+    public ChangePasswordResponseDto(UUID memberId, String loginPassword) {
         this.memberId = memberId;
+        this.loginPassword = loginPassword;
     }
 }

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/response/MemberIdResponseDto.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/response/MemberIdResponseDto.java
@@ -1,0 +1,17 @@
+package io.howstheairtoday.memberappexternalapi.service.dto.response;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberIdResponseDto {
+
+    private final UUID memberId;
+
+    @Builder
+    public MemberIdResponseDto(UUID memberId) {
+        this.memberId = memberId;
+    }
+}

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/response/ModifyNicknameResponseDto.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/response/ModifyNicknameResponseDto.java
@@ -1,0 +1,19 @@
+package io.howstheairtoday.memberappexternalapi.service.dto.response;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ModifyNicknameResponseDto {
+
+    private final UUID memberId;
+    private final String nickname;
+
+    @Builder
+    public ModifyNicknameResponseDto(UUID memberId, String nickname) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+    }
+}

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/response/ProfileImageResponseDto.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/response/ProfileImageResponseDto.java
@@ -1,0 +1,19 @@
+package io.howstheairtoday.memberappexternalapi.service.dto.response;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ProfileImageResponseDto {
+
+    private final UUID memberId;
+    private final String memberProfileImage;
+
+    @Builder
+    public ProfileImageResponseDto(UUID memberId, String memberProfileImage) {
+        this.memberId = memberId;
+        this.memberProfileImage = memberProfileImage;
+    }
+}

--- a/member-domain-rds/src/main/java/io/howstheairtoday/memberdomainrds/entity/Member.java
+++ b/member-domain-rds/src/main/java/io/howstheairtoday/memberdomainrds/entity/Member.java
@@ -81,16 +81,6 @@ public class Member extends BaseTimeEntity {
         this.refreshToken = refreshToken;
     }
 
-    // public Member modifiedMember(
-    //     final String modifiedPassword,
-    //     final String modifiedNickname,
-    //     final String modifiedProfileImage) {
-    //     this.loginPassword = modifiedPassword;
-    //     this.nickname = modifiedNickname;
-    //     this.memberProfileImage = modifiedProfileImage;
-    //     return this;
-    // }
-
     public void modifiyNickname(String nickname) {
         if (nickname != null) {
             this.nickname = nickname;
@@ -103,7 +93,7 @@ public class Member extends BaseTimeEntity {
         }
     }
 
-    public void modifiyProfileImage(String memberProfileImage) {
+    public void modifyProfileImage(String memberProfileImage) {
         if (memberProfileImage != null) {
             this.memberProfileImage = memberProfileImage;
         }

--- a/member-domain-rds/src/main/java/io/howstheairtoday/memberdomainrds/entity/Member.java
+++ b/member-domain-rds/src/main/java/io/howstheairtoday/memberdomainrds/entity/Member.java
@@ -33,7 +33,7 @@ public class Member extends BaseTimeEntity {
     @JdbcTypeCode(SqlTypes.VARCHAR)
     private UUID memberId;
 
-    @Column(nullable = false, length = 40)
+    @Column(nullable = false, length = 40, unique = true)
     private String loginId; // 아이디
 
     @Column(nullable = false, length = 128)
@@ -42,7 +42,7 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false, length = 50)
     private String email;
 
-    @Column(nullable = false, length = 40)
+    @Column(nullable = false, length = 40, unique = true)
     private String nickname;
 
     @Column(length = 128)
@@ -81,13 +81,31 @@ public class Member extends BaseTimeEntity {
         this.refreshToken = refreshToken;
     }
 
-    public Member modifiedMember(
-        final String modifiedPassword,
-        final String modifiedNickname,
-        final String modifiedProfileImage) {
-        this.loginPassword = modifiedPassword;
-        this.nickname = modifiedNickname;
-        this.memberProfileImage = modifiedProfileImage;
-        return this;
+    // public Member modifiedMember(
+    //     final String modifiedPassword,
+    //     final String modifiedNickname,
+    //     final String modifiedProfileImage) {
+    //     this.loginPassword = modifiedPassword;
+    //     this.nickname = modifiedNickname;
+    //     this.memberProfileImage = modifiedProfileImage;
+    //     return this;
+    // }
+
+    public void modifiyNickname(String nickname) {
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+    }
+
+    public void changePassword(String loginPassword) {
+        if (loginPassword != null) {
+            this.loginPassword = loginPassword;
+        }
+    }
+
+    public void modifiyProfileImage(String memberProfileImage) {
+        if (memberProfileImage != null) {
+            this.memberProfileImage = memberProfileImage;
+        }
     }
 }

--- a/member-domain-rds/src/test/java/io/howstheairtoday/memberdomainrds/repository/MemberRepositoryTest.java
+++ b/member-domain-rds/src/test/java/io/howstheairtoday/memberdomainrds/repository/MemberRepositoryTest.java
@@ -124,7 +124,7 @@ class MemberRepositoryTest {
             .refreshToken("TEST.REFRESH.TOKEN")
             .build();
         Member savedMember = memberRepository.save(member);
-        savedMember.modifiyProfileImage("modify.jpg");
+        savedMember.modifyProfileImage("modify.jpg");
 
         // when
         Optional<Member> foundMember = memberRepository.findByMemberId(savedMember.getMemberId());

--- a/member-domain-rds/src/test/java/io/howstheairtoday/memberdomainrds/repository/MemberRepositoryTest.java
+++ b/member-domain-rds/src/test/java/io/howstheairtoday/memberdomainrds/repository/MemberRepositoryTest.java
@@ -2,8 +2,10 @@ package io.howstheairtoday.memberdomainrds.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,6 +56,84 @@ class MemberRepositoryTest {
         assertThat(savedMember).isEqualTo(member);
     }
 
+    @DisplayName("회원 닉네임 수정")
+    @Test
+    public void modifiedMemberNickname() {
+
+        // given
+        Member member = Member.builder()
+            .loginId("testId")
+            .loginPassword("test123")
+            .email("test@test.com")
+            .nickname("testNick")
+            .memberProfileImage("default.jpg")
+            .loginType(LoginType.LOCAL)
+            .loginRole(LoginRole.ROLE_USER)
+            .refreshToken("TEST.REFRESH.TOKEN")
+            .build();
+        Member savedMember = memberRepository.save(member);
+        savedMember.modifiyNickname("modNick");
+
+        // when
+        List<Member> memberList = memberRepository.findAll();
+        Member result = memberList.get(0);
+
+        // then
+        Assertions.assertEquals(result.getNickname(), "modNick");
+    }
+
+    @DisplayName("회원 비밀번호 변경")
+    @Test
+    public void changeMemberPassword() {
+
+        // given
+        Member member = Member.builder()
+            .loginId("testId")
+            .loginPassword("test123")
+            .email("test@test.com")
+            .nickname("testNick")
+            .memberProfileImage("default.jpg")
+            .loginType(LoginType.LOCAL)
+            .loginRole(LoginRole.ROLE_USER)
+            .refreshToken("TEST.REFRESH.TOKEN")
+            .build();
+        Member savedMember = memberRepository.save(member);
+        savedMember.changePassword("mod123");
+
+        // when
+        Optional<Member> foundMember = memberRepository.findByMemberId(savedMember.getMemberId());
+
+        // then
+        assertThat(foundMember).isPresent();
+        assertThat(foundMember.get().getLoginPassword()).isEqualTo("mod123");
+    }
+
+    @DisplayName("회원 프로필 이미지 수정")
+    @Test
+    public void modifiedMemberProfileImage() {
+
+        // given
+        Member member = Member.builder()
+            .loginId("testId")
+            .loginPassword("test123")
+            .email("test@test.com")
+            .nickname("testNick")
+            .memberProfileImage("default.jpg")
+            .loginType(LoginType.LOCAL)
+            .loginRole(LoginRole.ROLE_USER)
+            .refreshToken("TEST.REFRESH.TOKEN")
+            .build();
+        Member savedMember = memberRepository.save(member);
+        savedMember.modifiyProfileImage("modify.jpg");
+
+        // when
+        Optional<Member> foundMember = memberRepository.findByMemberId(savedMember.getMemberId());
+
+        // then
+        assertThat(foundMember).isPresent();
+        assertThat(foundMember.get().getMemberProfileImage()).isEqualTo("modify.jpg");
+    }
+
     @DisplayName("회원 정보 삭제")
     @Test
     public void deleteMemberInfo() {
@@ -77,41 +157,6 @@ class MemberRepositoryTest {
         // then
         Optional<Member> deletedMember = memberRepository.findByMemberId(member.getMemberId());
         assertThat(deletedMember).isEmpty();
-    }
-
-    @DisplayName("회원 정보 수정")
-    @Test
-    public void modifyMemberInfo() {
-
-        // given
-        Member oldMember = Member.builder()
-            .loginId("testId")
-            .loginPassword("test123")
-            .email("test@test.com")
-            .nickname("testNick")
-            .memberProfileImage("default.jpg")
-            .loginType(LoginType.LOCAL)
-            .loginRole(LoginRole.ROLE_USER)
-            .refreshToken("TEST.REFRESH.TOKEN")
-            .build();
-        memberRepository.save(oldMember);
-
-        // when
-        String modifiedPassword = "modtest123";
-        String modifiedNickname = "modtestnick";
-        String modifiedProfileImage = "modimage.jpg";
-
-        Member modifiedMember = oldMember.modifiedMember(modifiedPassword, modifiedNickname, modifiedProfileImage);
-        memberRepository.save(modifiedMember);
-
-        // then
-        Optional<Member> findMember = memberRepository.findByMemberId(oldMember.getMemberId());
-        assertThat(findMember.isPresent()).isTrue();
-
-        Member member = findMember.get();
-        assertThat(member.getLoginPassword()).isEqualTo(modifiedPassword);
-        assertThat(member.getNickname()).isEqualTo(modifiedNickname);
-        assertThat(member.getMemberProfileImage()).isEqualTo(modifiedProfileImage);
     }
 
     @DisplayName("회원 정보 조회")


### PR DESCRIPTION
## Motivation:

- 마이페이지 구현을 위한 자신의 정보 수정 기능

## Modifications:

- 클라이언트가 로그인 이후 자신의 프로필에 들어가면 자신의 정보를 조회한 뒤 원하는 정보를 수정
- 수정 가능 컬럼
    - 패스워드
    - 이미지
    - 프로필 이미지
    

## Result:

- 프로필 이미지는 현재 String 값 변경으로 구현된 상태로 이후에 Amazon S3를 활용하면 수정이 필요함
- TODO: 서비스 테스트
### 패스워드 변경
![image](https://user-images.githubusercontent.com/117193889/231429012-6de17745-29f8-4ba9-8c14-a39158a38d81.png)


### 닉네임 수정
![image](https://user-images.githubusercontent.com/117193889/231429012-6de17745-29f8-4ba9-8c14-a39158a38d81.png)



### 프로필 이미지 수정

<img width="1292" alt="image" src="https://user-images.githubusercontent.com/117193889/231428863-19b8eaf3-c4a8-4e38-b25e-b9a8c487c3e9.png">
