### PR TITLE
♻️ refactor(HAT-66): TM 좌표 관련 메서드 제거 후 근처 측정소 찾는 API

### DIFF
--- a/air-quality-app-external-api/src/main/java/io/howstheairtoday/appairqualityexternalapi/controller/AirQualityRealTimeController.java
+++ b/air-quality-app-external-api/src/main/java/io/howstheairtoday/appairqualityexternalapi/controller/AirQualityRealTimeController.java
@@ -4,8 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,16 +21,18 @@ public class AirQualityRealTimeController {
     private final AirQualityRealTimeService airQualityRealTimeService;
 
     // 대기질 측정정보 조회
-    @GetMapping("/stationName/{umdName}")
+    @GetMapping("/tm")
     @ResponseBody
-    public Map<String, CurrentDustResponseDTO> selectAirQualityRealTime(@PathVariable("umdName") String umdName){
+    public Map<String, CurrentDustResponseDTO> selectAirQualityRealTime(@RequestParam("tmX") String tmX, @RequestParam("tmY") String tmY) {
 
-        // 근처 측정소 찾기
-        String stationName = airQualityRealTimeService.getNear(umdName);
+        System.out.println(tmX + " + " + tmY);
+        // TM 좌표를 이용하여 근처 측정소 찾기
+        String stationName = airQualityRealTimeService.getNear(tmX, tmY);
 
         // 데이터 값을 Map 으로 변환
         Map<String, CurrentDustResponseDTO> data = new HashMap<>();
         data.put("airQuality", airQualityRealTimeService.selectAirQualityRealTime(stationName));
+        System.out.println(data);
         return data;
     }
 }

--- a/air-quality-app-external-api/src/main/java/io/howstheairtoday/appairqualityexternalapi/controller/AirQualityRealTimeController.java
+++ b/air-quality-app-external-api/src/main/java/io/howstheairtoday/appairqualityexternalapi/controller/AirQualityRealTimeController.java
@@ -23,16 +23,14 @@ public class AirQualityRealTimeController {
     // 대기질 측정정보 조회
     @GetMapping("/tm")
     @ResponseBody
-    public Map<String, CurrentDustResponseDTO> selectAirQualityRealTime(@RequestParam("tmX") String tmX, @RequestParam("tmY") String tmY) {
+    public Map<String, CurrentDustResponseDTO> selectAirQualityRealTime(@RequestParam("tmx") String tmX, @RequestParam("tmy") String tmY) {
 
-        System.out.println(tmX + " + " + tmY);
         // TM 좌표를 이용하여 근처 측정소 찾기
         String stationName = airQualityRealTimeService.getNear(tmX, tmY);
 
         // 데이터 값을 Map 으로 변환
         Map<String, CurrentDustResponseDTO> data = new HashMap<>();
         data.put("airQuality", airQualityRealTimeService.selectAirQualityRealTime(stationName));
-        System.out.println(data);
         return data;
     }
 }

--- a/air-quality-app-external-api/src/main/java/io/howstheairtoday/appairqualityexternalapi/service/AirQualityRealTimeService.java
+++ b/air-quality-app-external-api/src/main/java/io/howstheairtoday/appairqualityexternalapi/service/AirQualityRealTimeService.java
@@ -52,7 +52,6 @@ public class AirQualityRealTimeService {
         // JSON 파싱
         JSONArray items = JsonToString(response.getBody());
         JSONObject item = items.getJSONObject(0);
-        System.out.println(items);
 
         //측정소명
         return item.getString("stationName");

--- a/air-quality-app-external-api/src/main/java/io/howstheairtoday/appairqualityexternalapi/service/AirQualityRealTimeService.java
+++ b/air-quality-app-external-api/src/main/java/io/howstheairtoday/appairqualityexternalapi/service/AirQualityRealTimeService.java
@@ -1,8 +1,5 @@
 package io.howstheairtoday.appairqualityexternalapi.service;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,58 +24,12 @@ public class AirQualityRealTimeService {
     @Value("${air.informationkey}")
     private String informationKey;
 
-    // 공공데이터 포털에서 TM좌표를 받아오기 위한 url
-    @Value("${air.tmUrl}")
-    private String tmUrl;
-
     // 공공데이터 포털에서 근처 측정소 위치를 받아오기 위한 url
     @Value("${air.nearUrl}")
     private String nearUrl;
 
-    // TM 좌표 찾아오기
-    public List<String> getTM(final String umdName) {
-
-        // RestTemplate를 통한 API 호출
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-
-        RestTemplate restTemplate = new RestTemplate();
-
-        // url 뒤에 붙일 내용들을 String으로 정의
-        String queryParams = "?serviceKey=" + informationKey
-            + "&returnType=json"
-            + "&numOfRows=100"
-            + "&pageNo=1"
-            + "&umdName=" + umdName;
-
-        ResponseEntity<String> response = restTemplate.exchange(tmUrl + queryParams, HttpMethod.GET, entity,
-            String.class);
-
-        // JSON 객체에 있는 값을 사용하기 위한 작업
-        JSONArray items = JsonToString(response.getBody());
-        JSONObject item = items.getJSONObject(0);
-
-        // tmX, tmY 좌표
-        String tmX = item.getString("tmX");
-        String tmY = item.getString("tmY");
-
-        List<String> tm = new ArrayList<>();
-        tm.add(tmX);
-        tm.add(tmY);
-
-        return tm;
-    }
-
     // TM 좌표를 통해 근접 측정소 찾기
-    public String getNear(final String umdName) {
-
-        // 위치 배열을 문자열 변수로 변경
-        List<String> tm;
-        tm = getTM(umdName);
-        String tmX = tm.get(0);
-        String tmY = tm.get(1);
+    public String getNear(final String tmX, final String tmY) {
 
         // RestTemplate를 통한 API 호출
         HttpHeaders headers = new HttpHeaders();
@@ -100,17 +51,8 @@ public class AirQualityRealTimeService {
 
         // JSON 파싱
         JSONArray items = JsonToString(response.getBody());
-
-        JSONObject item = null;
-
-        // 측정소명에 umdName이 포함된 item을 찾아서 stationName에 저장
-        for (int i = 0; i < items.length(); i++) {
-            item = items.getJSONObject(i);
-            String addr = item.getString("addr");
-            if (addr.contains(umdName)) {
-                break;
-            }
-        }
+        JSONObject item = items.getJSONObject(0);
+        System.out.println(items);
 
         //측정소명
         return item.getString("stationName");

--- a/air-quality-app-external-api/src/test/java/io/howstheairtoday/airqualityappexternalapi/controller/AirQualityRealTimeControllerTest.java
+++ b/air-quality-app-external-api/src/test/java/io/howstheairtoday/airqualityappexternalapi/controller/AirQualityRealTimeControllerTest.java
@@ -26,11 +26,12 @@ public class AirQualityRealTimeControllerTest {
     public void selectAirQualityRealTimeTest() throws Exception{
 
         // Given
-        String umdName = "서초동";
+        double tmX = 200817.7459347529;
+        double tmY = 443071.11499739345;
 
         // When
         // MockMvc 요청과 응답 설정
-        ResultActions resultActions = mockMvc.perform(get("/api/v1/airquality/stationName/{umdName}", umdName));
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/airquality/tm?tmX=" +  tmX + "&tmY=" + tmY));
 
         // Then
         resultActions.andExpect(status().isOk()).andDo(print());

--- a/air-quality-app-external-api/src/test/java/io/howstheairtoday/airqualityappexternalapi/controller/AirQualityRealTimeControllerTest.java
+++ b/air-quality-app-external-api/src/test/java/io/howstheairtoday/airqualityappexternalapi/controller/AirQualityRealTimeControllerTest.java
@@ -31,7 +31,7 @@ public class AirQualityRealTimeControllerTest {
 
         // When
         // MockMvc 요청과 응답 설정
-        ResultActions resultActions = mockMvc.perform(get("/api/v1/airquality/tm?tmX=" +  tmX + "&tmY=" + tmY));
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/airquality/tm?tmx=" +  tmX + "&tmy=" + tmY));
 
         // Then
         resultActions.andExpect(status().isOk()).andDo(print());

--- a/air-quality-app-external-api/src/test/java/io/howstheairtoday/airqualityappexternalapi/service/AirQualityRealTimeServiceTest.java
+++ b/air-quality-app-external-api/src/test/java/io/howstheairtoday/airqualityappexternalapi/service/AirQualityRealTimeServiceTest.java
@@ -26,52 +26,6 @@ import io.howstheairtoday.airqualitydomainrds.repository.AirQualityRealTimeRepos
 @SpringBootTest
 public class AirQualityRealTimeServiceTest {
 
-    @DisplayName("TM 좌표를 계산해주는 API 호출")
-    @Test
-    public void getTMTest() {
-
-        // Given
-        String expectedTMX = "171207.04807"; // 기대하는 tmX 좌표
-        String expectedTMY = "447286.409085"; // 기대하는 tmY 좌표
-
-        // RestTemplate를 통한 API 호출
-        RestTemplate restTemplate = new RestTemplate();
-
-        // url을 String으로 정의
-        String queryParams = "/test/api";
-
-        MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
-
-        // 예상되는 요청과 응답 설정
-        String expectedResponse = "{\"response\":{\"body\":{\"totalCount\":1,\"items\":[{\"sggName\":\"서구\",\"umdName\":\"가정동\",\"tmX\":\"171207.04807\",\"tmY\":\"447286.409085\",\"sidoName\":\"인천광역시\"}],\"pageNo\":1,\"numOfRows\":100},\"header\":{\"resultMsg\":\"NORMAL_CODE\",\"resultCode\":\"00\"}}}";
-        mockServer.expect(requestTo(queryParams))
-            .andExpect(method(HttpMethod.GET))
-            .andRespond(withSuccess(expectedResponse, MediaType.APPLICATION_JSON));
-
-
-        // When
-        // restTemplate 대신에 mockServer를 사용하여 API 호출
-        ResponseEntity<String> response = restTemplate.getForEntity(queryParams, String.class);
-
-        // Then
-
-        // 목 서버 검증
-        mockServer.verify();
-        // JSON 객체에 있는 값을 사용하기 위한 작업
-        assertNotNull(response.getBody());
-        JSONObject root = new JSONObject(response.getBody());
-        JSONObject res = root.getJSONObject("response");
-        JSONObject body = res.getJSONObject("body");
-        JSONArray items = body.getJSONArray("items");
-        JSONObject item = items.getJSONObject(0);
-
-        // tmX, tmY 좌표
-        String actualTMX = item.getString("tmX");
-        String actualTMY = item.getString("tmY");
-        assertEquals(expectedTMX, actualTMX);
-        assertEquals(expectedTMY, actualTMY);
-    }
-
     @DisplayName("가까운 측정소 위치 API 호출")
     @Test
     public void getNearTest() {


### PR DESCRIPTION
## Motivation:

- React에서 Geolocation을 통해 주소를 받아 처리를 할 때 중복되는 예외가 발생.

## Modifications:

- 예외를 처리해주기 위해 X, Y좌표를 TM 좌표로 바로 변환.

## Result:

- Controller에서 매개변수를 수정하고, Service에서 TM좌표를 받아 근처 측정소를 찾는 메서드로 수정.
- 관련 없는 Test 삭제
![image](https://user-images.githubusercontent.com/87405853/231763537-964e0584-223b-46d5-8951-ba5390cf3370.png)
