### PR TITLE
✨ feat(HAT-245): 로그아웃 기능 구현

### DIFF
--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/controller/AuthController.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/controller/AuthController.java
@@ -88,4 +88,13 @@ public class AuthController {
             .msg("이미지 변경이 완료 되었습니다.")
             .build();
     }
+
+    @PostMapping("/logout")
+    public ApiResponse<Object> logout() {
+        // 클라이언트 측에서 로그아웃 처리를 하면 됩니다.
+        return ApiResponse.<Object>builder()
+            .statusCode(HttpStatus.OK.value())
+            .msg("로그아웃이 완료되었습니다.")
+            .build();
+    }
 }

--- a/module-security/src/main/java/io/howstheairtoday/config/CustomSecurityConfig.java
+++ b/module-security/src/main/java/io/howstheairtoday/config/CustomSecurityConfig.java
@@ -114,6 +114,11 @@ public class CustomSecurityConfig {
 
         http.addFilterBefore(new RefreshTokenFilter("/api/**/auth/login", jwtUtil), TokenCheckFilter.class);
 
+        /**
+         * 로그아웃
+         */
+        http.logout().disable();
+
         http.csrf().disable();
         // Spring Security에서 세션을 사용하지 않도록 설정
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);

--- a/module-security/src/main/java/io/howstheairtoday/filter/TokenCheckFilter.java
+++ b/module-security/src/main/java/io/howstheairtoday/filter/TokenCheckFilter.java
@@ -75,7 +75,8 @@ public class TokenCheckFilter extends OncePerRequestFilter {
          */
         if (path.startsWith("/api/v1/post/") || // TODO: Post와 Member 개발 완료 후 제거
             path.startsWith("/api/v1/airquality/") ||
-            path.startsWith("/api/v1/auth/register")) {
+            path.startsWith("/api/v1/auth/register") ||
+            path.startsWith("/api/v1/auth/logout")) {
             filterChain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
## Motivation:

- 로그아웃 기능을 클라이언트단에서 수행하기 위한 설정 추가

## Modifications:

- 로그아웃을 클라이언트에서 수행해주기 위해 SecurityConfig에서 비활성화
- logout URL은 인증을 거칠 필요 없이 인증 값을 클라이언트에서 null로 비울 예정 

## Result:

- 클라이언트에서 로그인 로그아웃 결과를 추가. 🔗 https://github.com/Hows-the-Air-Today/HAT-frontend-react/pull/8

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/117193889/232437978-19e54040-2e23-4ce5-9f40-85513e15ff18.png">

