### PR TITLE
✨ feat(HAT-289) 멤버게시물이미지변경

### DIFF
--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/controller/AuthController.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/controller/AuthController.java
@@ -1,5 +1,6 @@
 package io.howstheairtoday.memberappexternalapi.controller;
 
+import java.io.IOException;
 import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
@@ -10,7 +11,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import io.howstheairtoday.memberappexternalapi.common.ApiResponse;
 import io.howstheairtoday.memberappexternalapi.service.AuthService;
@@ -21,10 +24,12 @@ import io.howstheairtoday.memberappexternalapi.service.dto.request.SignUpRequest
 import io.howstheairtoday.memberappexternalapi.service.dto.response.ProfileResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
+@Slf4j
 public class AuthController {
 
     private final AuthService authService;
@@ -81,9 +86,13 @@ public class AuthController {
     /**
      * 프로필 이미지 변경
      */
-    @PatchMapping("/profileimg")
-    public ApiResponse<Object> modifyProfileImg(@Valid @RequestBody final ModifyProfileImageRequestDto request) {
-        authService.modifyProfileImg(request);
+    @PatchMapping("/profile-change")
+    public ApiResponse<Object> modifyProfileImg(@RequestPart("profileImg") MultipartFile memberProfileImage,
+        UUID memberId) throws IOException {
+        log.info("memberProfileImage" + memberProfileImage);
+        log.info("memberId" + memberId);
+
+        authService.modifyProfileImg(memberId, memberProfileImage);
         return ApiResponse.<Object>builder()
             .statusCode(HttpStatus.OK.value())
             .msg("이미지 변경이 완료 되었습니다.")

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/ModifyProfileImageRequestDto.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/ModifyProfileImageRequestDto.java
@@ -2,6 +2,8 @@ package io.howstheairtoday.memberappexternalapi.service.dto.request;
 
 import java.util.UUID;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,5 +15,5 @@ import lombok.NoArgsConstructor;
 public class ModifyProfileImageRequestDto {
 
     private UUID memberId;
-    private String memberProfileImage;
+    private MultipartFile memberProfileImage;
 }

--- a/module-core/src/main/java/io/howstheairtoday/modulecore/service/AwsS3UploadService.java
+++ b/module-core/src/main/java/io/howstheairtoday/modulecore/service/AwsS3UploadService.java
@@ -76,6 +76,9 @@ public class AwsS3UploadService {
         String fileName = "";
         if (type.equals("게시판")) {
             fileName = "post/" + originalFileName + "_" + timeStamp + extension;
+        } else if (type.equals("프로필이미지")) {
+            fileName = "member/" + originalFileName + "_" + timeStamp + extension;
+
         }
         return fileName;
     }


### PR DESCRIPTION
## Motivation:

- 멤버 uuid 와 image를 통해 aws s3 저장하며, 업데이트를 한다 . 

## Modifications:

- 프론트에서 기능구현시 formData 로 
`UUID` ,`profileImg` 를 `append` 후  데이터를 보낸다 . 
- url 수정됨 

## Result:
<img width="1397" alt="스크린샷 2023-04-21 오후 11 56 22" src="https://user-images.githubusercontent.com/88875539/233668196-9f42d89f-8b2b-4fd9-bd90-703007f2599b.png">

-