### PR TITLE
♻️  refector(HAT-285): 백엔드게시물작성게시물수정

### DIFF
--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/config/MultiPartJacksonConfig.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/config/MultiPartJacksonConfig.java
@@ -1,0 +1,35 @@
+package io.howstheairtoday.appcommunityexternalapi.config;
+
+import java.lang.reflect.Type;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class MultiPartJacksonConfig extends AbstractJackson2HttpMessageConverter {
+
+    /**
+     * Converter for support http request with header Content-Type: multipart/form-data
+     */
+    public MultiPartJacksonConfig(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/PostController.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/PostController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import io.howstheairtoday.appcommunityexternalapi.common.ApiResponse;
 import io.howstheairtoday.appcommunityexternalapi.exception.posts.PostNotMember;
@@ -42,11 +43,11 @@ public class PostController {
      * @param saveRequestDto 생성할 게시글 정보
      * @return ApiResponse
      */
-    @PostMapping(path = "/")
+    @PostMapping(path = "/create-post")
     public ApiResponse<Object> createPost(
-        @Valid @RequestPart PostRequestDto.SaveRequestDto saveRequestDto,
-        @RequestPart List<PostRequestDto.PostImagesDto> postImages) {
-        externalPostService.createPost(saveRequestDto, postImages);
+        @RequestPart("saveRequestDto") final PostRequestDto.SaveRequestDto saveRequestDto,
+        @RequestPart("postImagesDto") final List<MultipartFile> postImagesDto) {
+        externalPostService.createPost(saveRequestDto, postImagesDto);
         return ApiResponse.<Object>builder()
             .statusCode(HttpStatus.CREATED.value())
             .msg("success")
@@ -54,11 +55,12 @@ public class PostController {
     }
 
     @PatchMapping("/{postsId}")
-    public ApiResponse<Object> updatePost(@Valid @RequestPart final PostRequestDto.SaveRequestDto saveRequestDto,
-        @RequestPart List<PostRequestDto.PostImagesDto> postImages,
+    public ApiResponse<Object> updatePost(
+        @RequestPart("saveRequestDto") final PostRequestDto.SaveRequestDto saveRequestDto,
+        @RequestPart("postImagesDto") final List<MultipartFile> postImagesDto,
         @PathVariable UUID postsId
     ) {
-        externalPostService.updatePost(saveRequestDto, postsId, postImages);
+        externalPostService.updatePost(saveRequestDto, postsId, postImagesDto);
         return ApiResponse.<Object>builder()
             .statusCode(HttpStatus.OK.value())
             .msg("success")

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/dto/request/PostRequestDto.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/dto/request/PostRequestDto.java
@@ -41,7 +41,6 @@ public class PostRequestDto {
         /**
          * 게시글에 첨부된 이미지 목록
          */
-        private List<PostImagesDto> postImageDtoList;
 
     }
 

--- a/community-app-external-api/src/test/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostServiceTest.java
+++ b/community-app-external-api/src/test/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostServiceTest.java
@@ -75,7 +75,7 @@ public class ExternalPostServiceTest {
 
         post.getImageArray()
             .forEach(postImage -> post.insertImages(
-                PostImage.create(postImage.getPostImageNumber(), postImage.getPostImageUrl(), post,
+                PostImage.create(postImage.getPostImageUrl(), post,
                     post.getMemberId())));
 
         //when
@@ -161,7 +161,7 @@ public class ExternalPostServiceTest {
             .memberId(UUID.fromString("dc718b8f-fb97-48d4-b55d-855e7c845987"))
             .build();
 
-        List<PostRequestDto.PostImagesDto> postImagesDtos = new ArrayList<>();
+        List<MultipartFile> postImagesDtos = new ArrayList<>();
 
         File newFile = new File(getClass().getClassLoader().getResource("qr.jpeg").getFile());
 
@@ -173,7 +173,7 @@ public class ExternalPostServiceTest {
             .postImageUrl(file)
             .build();
 
-        postImagesDtos.add(postImagesDto);
+        postImagesDtos.add(file);
 
         externalPostService.createPost(saveRequestDto, postImagesDtos);
     }

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/PostImage.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/PostImage.java
@@ -74,17 +74,8 @@ public class PostImage extends BaseTimeEntity {
         this.postId = post;
     }
 
-    /**
-     * 이미지 정보를 받아서 PostImage 인스턴스를 생성하는 메서드
-     *
-     * @param postImageNumber 이미지 순서 번호
-     * @param postImageUrl    이미지 URL
-     * @param post            해당 이미지와 연관된 포스트 엔티티
-     * @return 생성된 PostImage 인스턴스
-     */
-    public static PostImage create(Integer postImageNumber, String postImageUrl, Post post, final UUID memeberId) {
+    public static PostImage create(String postImageUrl, Post post, final UUID memeberId) {
         return PostImage.builder()
-            .postImageNumber(postImageNumber)
             .postImageUrl(postImageUrl)
             .post(post)
             .memeberId(memeberId)


### PR DESCRIPTION
## Motivation:

- 기존에 있던 코드를 수정 

## Modifications:

- MultiPart 컨버터를 등록한이유는 하나의 단일 이미지일경우는 데이터가 보내지지만, List형식으로 보낼땐 지원을 하지않아, 다음 리팩토링때 이미지 여러개일경우를 대비해서 등록함.

## Result:


<img width="673" alt="스크린샷 2023-04-22 오전 12 47 17" src="https://user-images.githubusercontent.com/88875539/233679539-228df320-5e31-43df-8d71-b994115f3470.png">
