### PR TITLE
✨ feat(HAT-304): 좋아요댓글관계매핑 인기게시글 조회

### DIFF
--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/Comment.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/Comment.java
@@ -7,11 +7,16 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
 import io.howstheairtoday.communitydomainrds.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -42,10 +47,13 @@ public class Comment extends BaseTimeEntity {
     @Column(name = "post_id")
     private UUID postId;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JsonBackReference
+    @JoinColumn(name = "post")
+    private Post post;
     //댓글 작성자 ID
     @Column(name = "memeber_id")
     private UUID memberId;
-
 
     @Builder
     public Comment(final String content, final UUID postId, final UUID memberId) {

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/Like.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/Like.java
@@ -6,10 +6,15 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,6 +46,11 @@ public class Like {
     //좋아요 누른 사용자 ID
     @Column(name = "memeber_id")
     private UUID memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JsonBackReference
+    @JoinColumn(name = "post")
+    private Post post;
 
     //좋아요 여부 변경
     public void changeStatus() {

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/Post.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/Post.java
@@ -24,54 +24,41 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-/**
- * 게시글 엔티티 클래스
- */
 @Entity
 @Table(name = "post")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Post extends BaseTimeEntity {
 
-    /**
-     * 게시글 ID
-     */
     @Id
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     @Column(name = "post_id", columnDefinition = "BINARY(16)")
     private UUID id;
 
-    /**
-     * 작성자 ID
-     */
     @Column(name = "member_id")
     private UUID memberId;
 
     @Column(name = "member_nickname")
     private String memberNickname;
 
-    /**
-     * 게시글 내용
-     */
     private String content;
 
-    /**
-     * 게시글 위치
-     */
     private String region;
 
-    /**
-     * 게시글 이미지 목록
-     */
+    @OneToMany(mappedBy = "post", fetch = FetchType.EAGER)
+    @JsonManagedReference
+    private List<Like> likes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", fetch = FetchType.EAGER)
+    @JsonManagedReference
+    private List<Comment> comment = new ArrayList<>();
+
     @OneToMany(mappedBy = "postId", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JsonManagedReference
     @Setter
     private List<PostImage> imageArray;
 
-    /**
-     * Post Builder
-     */
     @Builder
     public Post(final UUID id, final String content, final String region,
         final UUID memberId, final String memberNickname) {
@@ -82,13 +69,6 @@ public class Post extends BaseTimeEntity {
         this.imageArray = new ArrayList<>();
     }
 
-    /**
-     * 게시글 생성 메소드
-     *
-     * @param content 게시글 내용
-     * @param region  게시글 위치
-     * @return 생성된 게시글
-     */
     public static Post createPost(final String content, final String region, final UUID memberId,
         final String memberNickname) {
         return Post.builder()
@@ -99,9 +79,6 @@ public class Post extends BaseTimeEntity {
             .build();
     }
 
-    /**
-     * 게시글 삭제 메소드
-     */
     public void deletePost() {
         this.setDeletedAt(LocalDateTime.now());
         if (imageArray != null) {
@@ -109,12 +86,6 @@ public class Post extends BaseTimeEntity {
                 images.setDeletedAt(LocalDateTime.now()));
         }
     }
-
-    /**
-     * 게시글 이미지 추가 메소드
-     *
-     * @param postImage 추가할 게시글 이미지
-     */
 
     public void insertImages(PostImage postImage) {
         this.imageArray.add(postImage);

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/querydsl/PostQslImpl.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/querydsl/PostQslImpl.java
@@ -59,6 +59,7 @@ public class PostQslImpl extends QuerydslRepositorySupport implements PostQslRep
             .leftJoin(post.likes, qLike).fetchJoin()
             .where(post.region.eq(region))
             .groupBy(post.id)
+            .having(qLike.count().gt(0))
             .orderBy(qLike.count().desc())
             .limit(5);
 


### PR DESCRIPTION
## Motivation:

- 기존에 있던 게시글을 조회할때 좋아요개수,댓글개수,인기 게시글을 조회한다 

## Modifications:

- 연관관계매핑에대해서 `다`쪽엥 있는 부분까지 다 고쳐볼려했으나, 뭔가 뭐 건들고 뭐가 안되고 그럴거같아서, 관계만맺어놓고, `주형님`이 다시한번 `댓글` , `좋아요`  업데이트,작성 쪽 봐주시길 부탁드립니당  . 하는김에 다할려했으나... 뭔가 건들기가좀 그랬습니당! 


## Result:
![스크린샷 2023-04-22 오후 10 09 29](https://user-images.githubusercontent.com/88875539/233787080-c8c7acd0-e565-4a64-bfe4-241dd4196d0b.png)

-