### PR TITLE
♻️ refactor(HAT-300): 댓글 api 수정 및 DB매핑

### DIFF
--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/CommentController.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/CommentController.java
@@ -16,7 +16,9 @@ import org.springframework.web.bind.annotation.RestController;
 import io.howstheairtoday.appcommunityexternalapi.common.ApiResponse;
 import io.howstheairtoday.appcommunityexternalapi.service.dto.request.CommentRequestDTO;
 import io.howstheairtoday.appcommunityexternalapi.service.CommentService;
+import io.howstheairtoday.appcommunityexternalapi.service.dto.response.CommentResponseDTO;
 import io.howstheairtoday.communitydomainrds.dto.CommentPageListDTO;
+import io.howstheairtoday.communitydomainrds.entity.Post;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -29,19 +31,20 @@ public class CommentController {
 
     //게시물 댓글 작성
     @PostMapping("/{postId}/comments")
-    public ApiResponse<Object> createComment(@PathVariable("postId") UUID postId, @RequestBody CommentRequestDTO commentRequestDTO) {
+    public ApiResponse<Object> createComment(@PathVariable("postId") Post postId, @RequestBody CommentRequestDTO commentRequestDTO) {
 
-        commentService.createComment(postId, commentRequestDTO);
+        CommentResponseDTO commentResponseDTO = commentService.createComment(postId, commentRequestDTO);
 
         return ApiResponse.<Object>builder()
             .statusCode(HttpStatus.CREATED.value())
             .msg("작성 성공했습니다.")
+            .data(commentResponseDTO)
             .build();
     }
 
     //게시물 댓글 조회
     @GetMapping("/{postId}/comments")
-    public ApiResponse<CommentPageListDTO> getComment(@PathVariable("postId") UUID postId, Integer page) {
+    public ApiResponse<CommentPageListDTO> getComment(@PathVariable("postId") Post postId, Integer page) {
 
         CommentPageListDTO comments = commentService.getComment(postId, page);
 
@@ -76,3 +79,4 @@ public class CommentController {
             .build();
     }
 }
+

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/LikeController.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/LikeController.java
@@ -15,6 +15,7 @@ import io.howstheairtoday.appcommunityexternalapi.common.ApiResponse;
 import io.howstheairtoday.appcommunityexternalapi.service.LikeService;
 import io.howstheairtoday.appcommunityexternalapi.service.dto.request.LikeRequestDTO;
 import io.howstheairtoday.appcommunityexternalapi.service.dto.response.LikeResponseDTO;
+import io.howstheairtoday.communitydomainrds.entity.Post;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -25,7 +26,7 @@ public class LikeController {
     private final LikeService likeService;
 
     @PostMapping("/{postId}/likes")
-    public ApiResponse<Object> createLike(@PathVariable("postId") UUID postId, @RequestBody LikeRequestDTO likeRequestDTO) {
+    public ApiResponse<Object> createLike(@PathVariable("postId") Post postId, @RequestBody LikeRequestDTO likeRequestDTO) {
 
         LikeResponseDTO like = likeService.createLike(postId, likeRequestDTO);
 

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/CommentService.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/CommentService.java
@@ -7,9 +7,11 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 import io.howstheairtoday.appcommunityexternalapi.service.dto.request.CommentRequestDTO;
+import io.howstheairtoday.appcommunityexternalapi.service.dto.response.CommentResponseDTO;
 import io.howstheairtoday.communitydomainrds.dto.CommentPageListDTO;
 import io.howstheairtoday.communitydomainrds.entity.Comment;
 
+import io.howstheairtoday.communitydomainrds.entity.Post;
 import io.howstheairtoday.communitydomainrds.service.DomainCommunityService;
 import lombok.RequiredArgsConstructor;
 
@@ -20,21 +22,34 @@ public class CommentService {
     private final DomainCommunityService domainCommunityService;
 
     //게시물 댓글 작성 처리
-    public Comment createComment(UUID postId, CommentRequestDTO commentRequestDTO){
+    public CommentResponseDTO createComment(Post postId, CommentRequestDTO commentRequestDTO){
 
         Comment comment = Comment.builder()
-            .postId(postId)
+            .post(postId)
             .content(commentRequestDTO.getContent())
             .memberId(commentRequestDTO.getMemberId())
+            .nickName(commentRequestDTO.getNickname())
+            .memberProfileImage(commentRequestDTO.getMemberProfileImage())
             .build();
 
         domainCommunityService.saveComment(comment);
 
-        return comment;
+        CommentResponseDTO commentResponseDTO = CommentResponseDTO.builder()
+            .commentId(comment.getCommentId())
+            .content(comment.getContent())
+            .post(postId)
+            .memberId(comment.getMemberId())
+            .nickName(comment.getNickName())
+            .memberProfileImage(comment.getMemberProfileImage())
+            .createdAt(comment.getCreatedAt())
+            .updatedAt(comment.getUpdatedAt())
+            .build();
+
+        return commentResponseDTO;
     }
 
     //게시물 댓글 조회 처리
-    public CommentPageListDTO getComment(UUID postId, Integer pageable) {
+    public CommentPageListDTO getComment(Post postId, Integer pageable) {
 
         return domainCommunityService.getComment(postId, pageable);
     }

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/LikeService.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/LikeService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import io.howstheairtoday.appcommunityexternalapi.service.dto.request.LikeRequestDTO;
 import io.howstheairtoday.appcommunityexternalapi.service.dto.response.LikeResponseDTO;
 import io.howstheairtoday.communitydomainrds.entity.Like;
+import io.howstheairtoday.communitydomainrds.entity.Post;
 import io.howstheairtoday.communitydomainrds.service.DomainCommunityService;
 import lombok.RequiredArgsConstructor;
 
@@ -19,7 +20,7 @@ public class LikeService {
 
 
     //좋아요 등록 및 삭제 로직
-    public LikeResponseDTO createLike(UUID postId, LikeRequestDTO likeRequestDTO){
+    public LikeResponseDTO createLike(Post postId, LikeRequestDTO likeRequestDTO){
 
         Optional<Like> like = domainCommunityService.changeStatus(postId, likeRequestDTO.getMemberId());
 
@@ -42,7 +43,7 @@ public class LikeService {
         liked = Like.builder()
             .liked(true)
             .memberId(likeRequestDTO.getMemberId())
-            .postId(postId)
+            .post(postId)
             .build();
 
         domainCommunityService.saveLike(liked);
@@ -56,7 +57,7 @@ public class LikeService {
     }
 
     //좋아요 개수 출력
-    public int getLikeCount(UUID postId) {
+    public int getLikeCount(Post postId) {
         List<Like> likes = domainCommunityService.LikeCount(postId);
         int count = 0;
 

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/dto/request/CommentRequestDTO.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/dto/request/CommentRequestDTO.java
@@ -18,5 +18,11 @@ public class CommentRequestDTO {
 
     //댓글 작성자 아이디
     private UUID memberId;
+
+    //댓글 작성자 닉네임
+    private String nickname;
+
+    //댓글 작성자 프로필
+    private String memberProfileImage;
 }
 

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/dto/response/CommentResponseDTO.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/dto/response/CommentResponseDTO.java
@@ -1,4 +1,4 @@
-package io.howstheairtoday.communitydomainrds.dto;
+package io.howstheairtoday.appcommunityexternalapi.service.dto.response;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -13,7 +13,7 @@ import lombok.Data;
 @Data
 @Builder
 @AllArgsConstructor
-public class CommentPageDTO {
+public class CommentResponseDTO {
 
     private UUID commentId;
 
@@ -21,13 +21,11 @@ public class CommentPageDTO {
 
     private UUID memberId;
 
-    private UUID postId;
-
-    private Post post;
-
     private String nickName;
 
     private String memberProfileImage;
+
+    private Post post;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;

--- a/community-app-external-api/src/test/java/io/howstheairtoday/appcommunityexternalapi/service/LikeServiceTest.java
+++ b/community-app-external-api/src/test/java/io/howstheairtoday/appcommunityexternalapi/service/LikeServiceTest.java
@@ -1,6 +1,5 @@
 package io.howstheairtoday.appcommunityexternalapi.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.UUID;
@@ -15,8 +14,9 @@ import org.springframework.test.context.ActiveProfiles;
 import io.howstheairtoday.appcommunityexternalapi.service.dto.request.CommentRequestDTO;
 import io.howstheairtoday.appcommunityexternalapi.service.dto.request.LikeRequestDTO;
 import io.howstheairtoday.appcommunityexternalapi.service.dto.response.LikeResponseDTO;
-import io.howstheairtoday.communitydomainrds.entity.Comment;
-import io.howstheairtoday.communitydomainrds.entity.Like;
+import io.howstheairtoday.communitydomainrds.entity.Post;
+import io.howstheairtoday.communitydomainrds.entity.PostImage;
+import io.howstheairtoday.communitydomainrds.service.DomainCommunityService;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -27,19 +27,38 @@ class LikeServiceTest {
 
     private LikeRequestDTO likeRequestDTO;
 
-    private UUID postId;
+    @Autowired
+    private DomainCommunityService domainCommunityService;
+
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+
+        //given
+        post = Post.builder().region("서초구").content("게시글 내용").build();
+
+        PostImage postImage = PostImage.builder()
+            .postImageNumber(1)
+            .post(post)
+            .postImageUrl("https://amazons3.com/kjh")
+            .build();
+
+        post.insertImages(postImage);
+
+        domainCommunityService.savePost(post);
+    }
 
     @DisplayName("좋아요 등록 및 삭제")
     @Test
     public void createLike(){
 
-        postId = UUID.randomUUID();
 
         likeRequestDTO = likeRequestDTO.builder()
             .memberId(UUID.randomUUID())
             .build();
 
-        LikeResponseDTO savedLike = likeService.createLike(postId, likeRequestDTO);
+        LikeResponseDTO savedLike = likeService.createLike(post, likeRequestDTO);
 
         //then
         assertNotNull(savedLike);

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/Comment.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/Comment.java
@@ -43,24 +43,31 @@ public class Comment extends BaseTimeEntity {
     @Column(name = "content")
     private String content;
 
-    //게시물 ID
-    @Column(name = "post_id")
-    private UUID postId;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonBackReference
     @JoinColumn(name = "post")
     private Post post;
+
     //댓글 작성자 ID
     @Column(name = "memeber_id")
     private UUID memberId;
 
+    //댓글 작성자 닉네임
+    @Column(name = "memeber_nickname")
+    private String nickName;
+
+    //댓글 프로필 이미지
+    @Column(name = "member_profile_image")
+    private String memberProfileImage;
+
     @Builder
-    public Comment(final String content, final UUID postId, final UUID memberId) {
+    public Comment(final String content, final Post post, final UUID memberId, final String nickName, final String memberProfileImage) {
 
         this.content = content;
-        this.postId = postId;
+        this.post = post;
         this.memberId = memberId;
+        this.nickName = nickName;
+        this.memberProfileImage = memberProfileImage;
     }
 
     //내용 수정 테스트 메소드

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/Like.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/Like.java
@@ -39,10 +39,6 @@ public class Like {
     @Column(name = "liked")
     private Boolean liked;
 
-    //게시물 ID
-    @Column(name = "post_id")
-    private UUID postId;
-
     //좋아요 누른 사용자 ID
     @Column(name = "memeber_id")
     private UUID memberId;
@@ -58,10 +54,10 @@ public class Like {
     }
 
     @Builder
-    public Like(final Boolean liked, final UUID postId, final UUID memberId) {
+    public Like(final Boolean liked, final Post post, final UUID memberId) {
 
         this.liked = liked;
-        this.postId = postId;
+        this.post = post;
         this.memberId = memberId;
     }
 

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/repository/CommentRepository.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/repository/CommentRepository.java
@@ -9,8 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import io.howstheairtoday.communitydomainrds.entity.Comment;
+import io.howstheairtoday.communitydomainrds.entity.Post;
 
-@Repository
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
     Optional<Comment> findByCommentId(UUID commentId);

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/repository/LikeRepository.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/repository/LikeRepository.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Repository;
 
 import io.howstheairtoday.communitydomainrds.entity.Like;
 
-@Repository
 public interface LikeRepository extends JpaRepository<Like, UUID> {
 
     //게시물 좋아요 총 개수 출력

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/service/DomainCommunityService.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/service/DomainCommunityService.java
@@ -91,15 +91,15 @@ public class DomainCommunityService {
 
     //게시물 페이징 메소드
     @Transactional
-    public CommentPageListDTO getComment(UUID postId, Integer page) {
+    public CommentPageListDTO getComment(Post postId, Integer page) {
 
         int size = 10;
-        Sort.Direction direction = Sort.Direction.ASC;
+        Sort.Direction direction = Sort.Direction.DESC;
         String sort = "createdAt";
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sort));
 
-        Slice<Comment> comments = commentRepository.findByPostIdAndDeletedAtIsNull(postId, pageable);
+        Slice<Comment> comments = commentRepository.findByPostIdAndDeletedAtIsNull(postId.getId(), pageable);
 
         List<CommentPageDTO> commentDTOs = comments.getContent().stream()
             .map(comment -> {
@@ -107,7 +107,9 @@ public class DomainCommunityService {
                     .commentId(comment.getCommentId())
                     .content(comment.getContent())
                     .memberId(comment.getMemberId())
-                    .postId(comment.getPostId())
+                    .post(postId)
+                    .nickName(comment.getNickName())
+                    .memberProfileImage(comment.getMemberProfileImage())
                     .createdAt(comment.getCreatedAt())
                     .updatedAt(comment.getUpdatedAt())
                     .build();
@@ -140,15 +142,15 @@ public class DomainCommunityService {
 
     //게시물 좋아요 개수
     @Transactional
-    public List<Like> LikeCount(UUID postId) {
+    public List<Like> LikeCount(Post postId) {
 
-        return likeRepository.findLikeByPostIdIsAndLikedIsTrue(postId);
+        return likeRepository.findLikeByPostIdIsAndLikedIsTrue(postId.getId());
     }
 
     //좋아요 확인
     @Transactional
-    public Optional<Like> changeStatus(UUID postId, UUID memberId) {
-        return likeRepository.findLikeByPostIdAndMemberId(postId, memberId);
+    public Optional<Like> changeStatus(Post postId, UUID memberId) {
+        return likeRepository.findLikeByPostIdAndMemberId(postId.getId(), memberId);
     }
 
 }

--- a/community-domain-rds/src/test/java/io/howstheairtoday/communitydomainrds/repository/CommentRepositoryTest.java
+++ b/community-domain-rds/src/test/java/io/howstheairtoday/communitydomainrds/repository/CommentRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,19 +20,29 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.howstheairtoday.communitydomainrds.entity.Comment;
+import io.howstheairtoday.communitydomainrds.entity.Post;
 
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ContextConfiguration(classes = {CommentRepository.class})
+@ContextConfiguration(classes = {CommentRepositoryTest.class})
 @EnableJpaRepositories(basePackages = "io.howstheairtoday.communitydomainrds.repository")
 @EntityScan("io.howstheairtoday.communitydomainrds.entity")
-@Transactional(propagation = Propagation.NOT_SUPPORTED)
 public class CommentRepositoryTest {
 
     @Autowired
     private CommentRepository commentRepository;
 
+    @Autowired
+    private PostRepository postRepository;
+
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        post = Post.builder().region("동남로").content("게시글 내용").build();
+        postRepository.save(post);
+    }
     @DisplayName("댓글 작성")
     @Test
     public void insertComment() {
@@ -40,7 +51,7 @@ public class CommentRepositoryTest {
         Comment comment = Comment.builder()
             .memberId(UUID.randomUUID())
             .content("댓글3")
-            .postId(UUID.randomUUID())
+            .post(post)
             .build();
 
         //when
@@ -58,8 +69,9 @@ public class CommentRepositoryTest {
         Comment comment2 = Comment.builder()
             .memberId(UUID.randomUUID())
             .content("댓글6")
-            .postId(UUID.randomUUID())
+            .post(post)
             .build();
+
         commentRepository.save(comment2);
 
         //when
@@ -78,7 +90,7 @@ public class CommentRepositoryTest {
         Comment comment1 = Comment.builder()
             .memberId(UUID.randomUUID())
             .content("댓글4")
-            .postId(UUID.randomUUID())
+            .post(post)
             .build();
         commentRepository.save(comment1);
 
@@ -98,7 +110,7 @@ public class CommentRepositoryTest {
         Comment comment = Comment.builder()
             .memberId(UUID.randomUUID())
             .content("댓글15")
-            .postId(UUID.randomUUID())
+            .post(post)
             .build();
 
         //when

--- a/community-domain-rds/src/test/java/io/howstheairtoday/communitydomainrds/repository/LikeRepositoryTest.java
+++ b/community-domain-rds/src/test/java/io/howstheairtoday/communitydomainrds/repository/LikeRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 import java.util.UUID;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,18 +17,29 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import io.howstheairtoday.communitydomainrds.entity.Like;
+import io.howstheairtoday.communitydomainrds.entity.Post;
 
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ContextConfiguration(classes = {LikeRepository.class})
+@ContextConfiguration(classes = {LikeRepositoryTest.class})
 @EnableJpaRepositories(basePackages = "io.howstheairtoday.communitydomainrds.repository")
 @EntityScan("io.howstheairtoday.communitydomainrds.entity")
-@Transactional(propagation = Propagation.NOT_SUPPORTED)
 public class LikeRepositoryTest {
 
     @Autowired
     private LikeRepository likeRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        post = Post.builder().region("동남로").content("게시글 내용").build();
+        postRepository.save(post);
+    }
 
     @DisplayName("좋아요 등록")
     @Test
@@ -36,7 +48,7 @@ public class LikeRepositoryTest {
         //given
         Like liked = Like.builder()
             .memberId(UUID.randomUUID())
-            .postId(UUID.randomUUID())
+            .post(post)
             .liked(true)
             .build();
 
@@ -54,7 +66,7 @@ public class LikeRepositoryTest {
         //given
         Like liked = Like.builder()
             .memberId(UUID.randomUUID())
-            .postId(UUID.randomUUID())
+            .post(post)
             .liked(true)
             .build();
         likeRepository.save(liked);


### PR DESCRIPTION
## Motivation:

- 댓글 API 수정
- 댓글, 좋아요, 게시물 매핑

## Modifications:

- 댓글 API에서 조회할 때 값을 response 하도록 수정
- 댓글, 좋아요를 게시물 Post 와 매핑

## Result:

- 데이터베이스 
![image](https://user-images.githubusercontent.com/54580802/234246843-af4ed101-be91-46e1-b184-065910531b23.png)
