### PR TITLE
♻️ refactor(HAT-326): 내 게시물조회 

### DIFF
--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/PostController.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/PostController.java
@@ -77,8 +77,8 @@ public class PostController {
             .build();
     }
 
-    @GetMapping("/post-detail")
-    public ApiResponse<Object> getDetailPost(@RequestParam UUID postsId
+    @GetMapping("/post-detail/{postsId}")
+    public ApiResponse<Object> getDetailPost(@PathVariable UUID postsId
     ) {
         PostResponseDto.PostResponseDetail dto = externalPostService.getDetailPost(postsId);
         return ApiResponse.<Object>builder()

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/PostController.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/PostController.java
@@ -80,7 +80,7 @@ public class PostController {
     @GetMapping("/post-detail/{postsId}")
     public ApiResponse<Object> getDetailPost(@PathVariable UUID postsId
     ) {
-        PostResponseDto.PostResponseDetail dto = externalPostService.getDetailPost(postsId);
+        PostResponseDto.PostDto dto = externalPostService.getDetailPost(postsId);
         return ApiResponse.<Object>builder()
             .statusCode(HttpStatus.OK.value())
             .msg("success")

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostService.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostService.java
@@ -101,26 +101,15 @@ public class ExternalPostService {
         domainCommunityService.savePost(post);
     }
 
-    public PostResponseDto.PostResponseDetail getDetailPost(UUID postsId) {
+    public PostResponseDto.PostDto getDetailPost(UUID postsId) {
 
         Post getDetailPost = domainCommunityService.findById(postsId).orElseThrow(PostNotExistException::new);
-
-        List<PostResponseDto.PostImageResponseDto> imagesDtos = getDetailPost.getImageArray().stream()
-            .map(postImage -> PostResponseDto.PostImageResponseDto.builder()
-                .imageId(postImage.getPostImageId())
-                .memberId(postImage.getMemberId())
-                .postId(postImage.getPostId().getId())
-                .imageNumber(postImage.getPostImageNumber())
-                .imageUrl(postImage.getPostImageUrl())
-                .createdAt(postImage.getCreatedAt())
-                .updatedAt(postImage.getUpdatedAt())
-                .deletedAt(postImage.getDeletedAt())
-                .build())
-            .collect(Collectors.toList());
 
         PostResponseDto.PostDto postDto = PostResponseDto.PostDto.builder()
             .postId(getDetailPost.getId())
             .region(getDetailPost.getRegion())
+            .imageUrl(getDetailPost.getImageArray().get(0).getPostImageUrl())
+            .content(getDetailPost.getContent())
             .memberId(getDetailPost.getMemberId())
             .memberNickname(getDetailPost.getMemberNickname())
             .content(getDetailPost.getContent())
@@ -129,12 +118,8 @@ public class ExternalPostService {
             .createdAt(getDetailPost.getCreatedAt())
             .build();
 
-        PostResponseDto.PostResponseDetail getPostresponseDetail = PostResponseDto.PostResponseDetail.builder()
-            .postDto(postDto)
-            .imageDto(imagesDtos)
-            .build();
 
-        return getPostresponseDetail;
+        return postDto;
 
     }
 

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/dto/response/PostResponseDto.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/dto/response/PostResponseDto.java
@@ -35,6 +35,7 @@ public class PostResponseDto {
         private String content;
         private String memberNickname;
         private String region;
+        private String imageUrl;
 
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
@@ -48,6 +49,7 @@ public class PostResponseDto {
 
         private UUID imageId;
         private UUID memberId;
+        private String content;
 
         private UUID postId;
         private String imageUrl;

--- a/community-app-external-api/src/test/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostServiceTest.java
+++ b/community-app-external-api/src/test/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostServiceTest.java
@@ -201,12 +201,11 @@ public class ExternalPostServiceTest {
         Post getPost = domainCommunityService.findById(post.getId()).orElseThrow(PostNotExistException::new);
 
         //when
-        PostResponseDto.PostResponseDetail postResponseDetail = externalPostService.getDetailPost(getPost.getId());
+        PostResponseDto.PostDto postResponseDetail = externalPostService.getDetailPost(getPost.getId());
 
         //then
         assertThat(getPost.getContent()).isEqualTo("게시글 내용");
         assertThat(getPost.getRegion()).isEqualTo("동남로");
-        assertThat(getPost.getId()).isEqualTo(postResponseDetail.getPostDto().getPostId());
     }
 
     @DisplayName("게시물 조회")

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/repository/PostRepository.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/repository/PostRepository.java
@@ -17,7 +17,9 @@ public interface PostRepository extends JpaRepository<Post, UUID> {
 
     Optional<Post> findById(UUID uuid);
 
-    @Query("SELECT pi FROM PostImage pi WHERE pi.memberId = :memberId AND pi.deletedAt IS NULL ORDER BY pi.createdAt DESC")
-    List<PostImage> findByMemberIdAndDeletedAtIsNull(@Param("memberId") UUID memberId);
+    @Query(
+        "SELECT p FROM Post p JOIN FETCH p.imageArray WHERE p.memberId = :memberId AND p.deletedAt IS NULL ORDER BY p"
+            + ".createdAt DESC")
+    List<Post> findByMemberIdAndDeletedAtIsNull(@Param("memberId") UUID memberId);
 
 }

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/service/DomainCommunityService.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/service/DomainCommunityService.java
@@ -73,11 +73,11 @@ public class DomainCommunityService {
 
     @Transactional
     public List<DomainPostResponseDto.PostImageDto> getMyPost(UUID memberId) {
-        List<PostImage> list = postRepository.findByMemberIdAndDeletedAtIsNull(memberId);
+        List<Post> list = postRepository.findByMemberIdAndDeletedAtIsNull(memberId);
 
         List<DomainPostResponseDto.PostImageDto> domainPostImageDto = list.stream().
-            map(postImage -> new DomainPostResponseDto.PostImageDto(postImage.getPostImageUrl(),
-                postImage.getMemberId(), postImage.getPostImageId()))
+            map(postImage -> new DomainPostResponseDto.PostImageDto(postImage.getImageArray().get(0).getPostImageUrl(),
+                postImage.getMemberId(), postImage.getId()))
             .collect(Collectors.toList());
         return domainPostImageDto;
     }

--- a/community-domain-rds/src/test/java/io/howstheairtoday/communitydomainrds/repository/PostRepositoryTest.java
+++ b/community-domain-rds/src/test/java/io/howstheairtoday/communitydomainrds/repository/PostRepositoryTest.java
@@ -204,7 +204,7 @@ public class PostRepositoryTest {
         }
         postRepository.save(post);
 
-        List<PostImage> getMyPost = postRepository.findByMemberIdAndDeletedAtIsNull(memberId);
+        List<Post> getMyPost = postRepository.findByMemberIdAndDeletedAtIsNull(memberId);
 
         Assertions.assertThat(getMyPost).isNotEmpty();
         Assertions.assertThat(getMyPost.get(0).getMemberId()).isEqualTo(memberId);


### PR DESCRIPTION
## Motivation:

- 나의 게시물을 조회한다 

## Modifications:

- memberId를 통해 나의 게시물을 조회했을때 단일 게시물에대한 상세 게시물로 이동할때 , postId를 넘겨, 게시물상세를 구현할려하였으나, 게시물을 생성을 했는데도 불구하고, 계속되는 `Exception`이 발생하여,  해당 문제를 다시 보니 , postImage에 대한 `id`를 받아오고있었음. 
그러므로 해당 로직을 다시 수정하였습니다. 

## Result:

- 이전 로직은 ImageList가 여러개일때생각 한 로직이여서 너무 불필요하다 생각하여 다시 수정해서 고쳤습니다.
- 또 다시 `create`해버렸네요 ㅎㅎ..실.수 ㅎㅎ 
