### PR TITLE
♻️ refactor(HAT-333): 게시물업데이트로직수정

### DIFF
--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/PostController.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/PostController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -57,10 +58,11 @@ public class PostController {
     @PatchMapping("/{postsId}")
     public ApiResponse<Object> updatePost(
         @RequestPart("saveRequestDto") final PostRequestDto.SaveRequestDto saveRequestDto,
-        @RequestPart("postImagesDto") final List<MultipartFile> postImagesDto,
+        @RequestPart(value = "postImagesDto", required = false) final List<MultipartFile> postImagesDto,
+        @RequestPart(value = "stringImagesDto", required = false) @Nullable final String stringImagesDto,
         @PathVariable UUID postsId
     ) {
-        externalPostService.updatePost(saveRequestDto, postsId, postImagesDto);
+        externalPostService.updatePost(saveRequestDto, postsId, postImagesDto, stringImagesDto);
         return ApiResponse.<Object>builder()
             .statusCode(HttpStatus.OK.value())
             .msg("success")


### PR DESCRIPTION
## Motivation:

- 게시물 업데이트 로직 수정 

## Modifications:

- 기존에 있던 서비스로직에서 사용자가 이미지를 변경하지않았을경우 데이터 타입은 `string`이기 때문에 그 부분을 조건을 추가하여 로직을 추가하였습니다. 
- update 컨트롤러에서 받는 로직은 `MultipartFile` 타입이기에 업데이트할시, 사용자가 만약, 이미지를 변경하지않고 업데이트를 할경우 타입이안맞아서, request를 보내지 못하는 상황이옵니다. 이러한 예외를 잡아주기위한 로직입니다. 

## Result:

- 업데이트로직 완료  