### PR TITLE
♻️ refactor(HAT-340): 게시물좋아요수정및인기게시글수정 

### DIFF
--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/PostController.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/controller/PostController.java
@@ -106,6 +106,18 @@ public class PostController {
             .build();
     }
 
+    @GetMapping("/get-popular")
+    public ApiResponse<Object> getPopularList(
+        @RequestParam("region") String region
+    ) {
+        List<PostResponseDto.PopularList> popularList = externalPostService.getPopularList(region);
+        return ApiResponse.<Object>builder()
+            .statusCode(HttpStatus.OK.value())
+            .msg("success")
+            .data(popularList)
+            .build();
+    }
+
     @GetMapping("my-page/{memberId}")
     public ApiResponse<Object> getDetailMyPagePost(@PathVariable UUID memberId
     ) {

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostService.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostService.java
@@ -157,7 +157,7 @@ public class ExternalPostService {
         List<PostResponseDto.PopularList> popularDtoList = popularPosts.stream()
             .map(post -> {
                 return new PostResponseDto.PopularList(post.getId(), post.getMemberId(), post.getContent(),
-                    post.getMemberNickname(), post.getRegion(), post.getMemberImage());
+                    post.getMemberNickname(), post.getRegion(), post.getImageArray().get(0).getPostImageUrl());
             })
             .collect(Collectors.toList());
         return popularDtoList;

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostService.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostService.java
@@ -150,4 +150,16 @@ public class ExternalPostService {
                 .collect(Collectors.toList());
         return list;
     }
+
+    public List<PostResponseDto.PopularList> getPopularList(String region) {
+
+        List<Post> popularPosts = domainCommunityService.getPopularList(region);
+        List<PostResponseDto.PopularList> popularDtoList = popularPosts.stream()
+            .map(post -> {
+                return new PostResponseDto.PopularList(post.getId(), post.getMemberId(), post.getContent(),
+                    post.getMemberNickname(), post.getRegion(), post.getMemberImage());
+            })
+            .collect(Collectors.toList());
+        return popularDtoList;
+    }
 }

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/dto/response/PostResponseDto.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/dto/response/PostResponseDto.java
@@ -29,6 +29,7 @@ public class PostResponseDto {
 
     @Getter
     @Builder
+    @AllArgsConstructor
     public static class PostDto {
         private UUID postId;
         private UUID memberId;
@@ -72,6 +73,21 @@ public class PostResponseDto {
         private String postImageUrl;
         private UUID memberId;
         private UUID postId;
+
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class PopularList {
+        // private final List<> popularList;
+        private UUID postId;
+        private UUID memberId;
+        private String content;
+        private String memberNickname;
+        private String region;
+        private String imageUrl;
+
 
     }
 }

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/repository/PostQslRepository.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/repository/PostQslRepository.java
@@ -14,4 +14,5 @@ public interface PostQslRepository {
 
     List<Map<String, Object>> findByRegionList(String region, LocalDateTime createdAt, int limit);
 
+    List<Post> findBylikesList(String region);
 }

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/service/DomainCommunityService.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/service/DomainCommunityService.java
@@ -153,4 +153,8 @@ public class DomainCommunityService {
         return likeRepository.findLikeByPostIdAndMemberId(postId.getId(), memberId);
     }
 
+    public List<Post> getPopularList(String region) {
+
+        return postQslRepository.findBylikesList(region);
+    }
 }

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/service/dto/PostDomainResponseDto.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/service/dto/PostDomainResponseDto.java
@@ -12,7 +12,7 @@ public class PostDomainResponseDto {
     private List<Map<String, Object>> data;
 
     @Builder
-    public PostDomainResponseDto(List<Map<String, Object>> data) {
+    public PostDomainResponseDto(List<Map<String, Object>> data ) {
         this.data = data;
     }
 }


### PR DESCRIPTION
## Motivation:

- 게시글 좋아요 및 게시글 조회 수정. 

## Modifications:

- 기존에 게시물을 전체조회할경우 좋아요가 데이터유실성이 발생함. fetchJoin을통해서 데이터가 유실이되는걸확인후, 주석처리함. 
- 초기에는 게시물을 조회할때 인기게시물까지 다 주는 생각을했는데 생각을해보니 무한스크롤을 하면서 계속 그때마다 데이터 호출하는걸 보게되었다. 이렇게 될경우 너무 서버에 부담이 갈 가능성이높고 실시간으로 보여주는게아닌이상 이렇게 주는게 안좋다고 판단하여 , 따로 컨트롤러를 파게되었다. 데이터를 뽑아오는 조건은  
- `게시물 region에서 제일 좋아요가 많은순이면서 좋아요가 0개이상인것들로부터 필터를 시작한다. 그 후 게시물좋아요들이 죄다 3개씩 갖는경우를 고려하여 게시물최신순 기준 좋아요가높은순이며, limt을 걸어 5개만갖고오도록하였다. `

## Result:

-
<img width="471" alt="스크린샷 2023-04-28 오후 3 01 35" src="https://user-images.githubusercontent.com/88875539/235066861-0e5fdc86-0f64-47ed-a549-4a45998edb4c.png">
