### PR TITLE
✨ feat(HAT-341): 회원 Controller Test

### DIFF
--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/ChangePasswordRequestDto.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/ChangePasswordRequestDto.java
@@ -5,8 +5,10 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChangePasswordRequestDto {

--- a/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/ModifyNicknameRequestDto.java
+++ b/member-app-external-api/src/main/java/io/howstheairtoday/memberappexternalapi/service/dto/request/ModifyNicknameRequestDto.java
@@ -5,8 +5,10 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ModifyNicknameRequestDto {

--- a/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/controller/AuthControllerTest.java
+++ b/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/controller/AuthControllerTest.java
@@ -1,0 +1,57 @@
+package io.howstheairtoday.memberappexternalapi.controller;
+
+import static org.springframework.mock.http.server.reactive.MockServerHttpRequest.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.howstheairtoday.memberappexternalapi.common.AbstractRestDocsTests;
+import io.howstheairtoday.memberappexternalapi.service.dto.request.SignUpRequestDTO;
+
+@DisplayName("회원 API 테스트")
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@SpringBootTest
+public class AuthControllerTest extends AbstractRestDocsTests {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final String BASE_URL = "/api/v1/auth";
+
+    @DisplayName("회원가입")
+    @Test
+    public void registerMemberTest() throws Exception {
+
+        // given
+        SignUpRequestDTO signUpRequestDTO = new SignUpRequestDTO();
+        signUpRequestDTO.setLoginId("test");
+        signUpRequestDTO.setLoginPassword("test123");
+        signUpRequestDTO.setLoginPasswordCheck("test123");
+        signUpRequestDTO.setEmail("test@test.com");
+        signUpRequestDTO.setNickname("테스트");
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.post(BASE_URL + "/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(signUpRequestDTO))
+        );
+
+        // then
+        resultActions.andExpect(status().isOk()).andDo(print());
+    }
+}

--- a/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/controller/AuthControllerTest.java
+++ b/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/controller/AuthControllerTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.howstheairtoday.memberappexternalapi.common.AbstractRestDocsTests;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.SignUpRequestDTO;
+import io.howstheairtoday.memberdomainrds.entity.LoginRole;
 import io.howstheairtoday.memberdomainrds.entity.Member;
 import io.howstheairtoday.memberdomainrds.repository.MemberRepository;
 
@@ -62,6 +63,34 @@ public class AuthControllerTest extends AbstractRestDocsTests {
             MockMvcRequestBuilders.post(BASE_URL + "/register")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(signUpRequestDTO))
+        );
+
+        // then
+        resultActions.andExpect(status().isOk()).andDo(print());
+    }
+
+    @DisplayName("회원 정보 조회")
+    @Test
+    public void readMemberTest() throws Exception {
+
+        // given
+        Member member = Member.builder()
+            .loginId("test")
+            .loginPassword("test123")
+            .email("test@test.com")
+            .nickname("테스트")
+            .memberProfileImage("default.jpg")
+            .loginRole(LoginRole.ROLE_USER)
+            .build();
+        memberRepository.save(member);
+
+        String accessToken = "example_access_token";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.get(BASE_URL + "/" + member.getMemberId())
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
         );
 
         // then

--- a/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/controller/AuthControllerTest.java
+++ b/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/controller/AuthControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.howstheairtoday.memberappexternalapi.common.AbstractRestDocsTests;
+import io.howstheairtoday.memberappexternalapi.service.dto.request.ChangePasswordRequestDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.ModifyNicknameRequestDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.SignUpRequestDTO;
 import io.howstheairtoday.memberdomainrds.entity.LoginRole;
@@ -129,5 +130,42 @@ public class AuthControllerTest extends AbstractRestDocsTests {
 
         // then
         resultActions.andExpect(status().isOk()).andDo(print());
+    }
+
+    @DisplayName("회원 비밀번호 변경")
+    @Test
+    public void changePasswordTest() throws Exception {
+
+        // given
+        Member member = Member.builder()
+            .loginId("test")
+            .loginPassword("test123")
+            .email("test@test.com")
+            .nickname("테스트")
+            .memberProfileImage("default.jpg")
+            .loginRole(LoginRole.ROLE_USER)
+            .build();
+        memberRepository.save(member);
+
+        ChangePasswordRequestDto requestDto = new ChangePasswordRequestDto();
+        requestDto.setMemberId(member.getMemberId());
+        requestDto.setLoginPassword("test321");
+        requestDto.setLoginPasswordCheck("test321"); // 새로운 비밀번호 확인
+
+        String accessToken = "example_access_token";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.patch(BASE_URL + "/password")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto))
+        );
+
+        // then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.msg").value("비밀번호 변경이 완료 되었습니다."))
+            .andDo(print());
     }
 }

--- a/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/controller/AuthControllerTest.java
+++ b/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/controller/AuthControllerTest.java
@@ -1,10 +1,11 @@
 package io.howstheairtoday.memberappexternalapi.controller;
 
-import static org.springframework.mock.http.server.reactive.MockServerHttpRequest.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +13,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.howstheairtoday.memberappexternalapi.common.AbstractRestDocsTests;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.SignUpRequestDTO;
+import io.howstheairtoday.memberdomainrds.entity.Member;
+import io.howstheairtoday.memberdomainrds.repository.MemberRepository;
 
 @DisplayName("회원 API 테스트")
 @ActiveProfiles("test")
@@ -31,6 +33,17 @@ public class AuthControllerTest extends AbstractRestDocsTests {
     private ObjectMapper objectMapper;
 
     private static final String BASE_URL = "/api/v1/auth";
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @AfterEach
+    public void deletData() {
+
+        Optional<Member> member = memberRepository.findByLoginId("test");
+        if (member != null) {
+            memberRepository.delete(member.get());
+        }
+    }
 
     @DisplayName("회원가입")
     @Test

--- a/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/controller/AuthControllerTest.java
+++ b/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/controller/AuthControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.howstheairtoday.memberappexternalapi.common.AbstractRestDocsTests;
+import io.howstheairtoday.memberappexternalapi.service.dto.request.ModifyNicknameRequestDto;
 import io.howstheairtoday.memberappexternalapi.service.dto.request.SignUpRequestDTO;
 import io.howstheairtoday.memberdomainrds.entity.LoginRole;
 import io.howstheairtoday.memberdomainrds.entity.Member;
@@ -91,6 +92,39 @@ public class AuthControllerTest extends AbstractRestDocsTests {
             MockMvcRequestBuilders.get(BASE_URL + "/" + member.getMemberId())
                 .header("Authorization", "Bearer " + accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk()).andDo(print());
+    }
+
+    @DisplayName("회원 닉네임 수정")
+    @Test
+    public void modifyNicknameTest() throws Exception {
+
+        // given
+        Member member = Member.builder()
+            .loginId("test")
+            .loginPassword("test123")
+            .email("test@test.com")
+            .nickname("테스트")
+            .memberProfileImage("default.jpg")
+            .loginRole(LoginRole.ROLE_USER)
+            .build();
+        memberRepository.save(member);
+
+        ModifyNicknameRequestDto requestDto = new ModifyNicknameRequestDto();
+        requestDto.setMemberId(member.getMemberId());
+        requestDto.setNickname("수정된 닉네임");
+
+        String accessToken = "example_access_token";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.patch(BASE_URL + "/nickname")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto))
         );
 
         // then

--- a/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/controller/AuthControllerTest.java
+++ b/member-app-external-api/src/test/java/io/howstheairtoday/memberappexternalapi/controller/AuthControllerTest.java
@@ -168,4 +168,32 @@ public class AuthControllerTest extends AbstractRestDocsTests {
             .andExpect(jsonPath("$.msg").value("비밀번호 변경이 완료 되었습니다."))
             .andDo(print());
     }
+
+    @DisplayName("회원탈퇴")
+    @Test
+    public void deleteMemberTest() throws Exception {
+
+        // given
+        Member member = Member.builder()
+            .loginId("test")
+            .loginPassword("test123")
+            .email("test@test.com")
+            .nickname("테스트")
+            .memberProfileImage("default.jpg")
+            .loginRole(LoginRole.ROLE_USER)
+            .build();
+        memberRepository.save(member);
+
+        String accessToken = "example_access_token";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.delete(BASE_URL + "/" + member.getMemberId())
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk()).andDo(print());
+    }
 }


### PR DESCRIPTION
## Motivation:

- 회원 컨트롤러 TEST

## Modifications:

- RestDocs 대비 Test 코드 작성

## Result:

- 아래의 이미지를 참조
<img width="263" alt="image" src="https://user-images.githubusercontent.com/117193889/235131587-b1b3140e-82c6-49b0-8b4c-1ff8e67c9e81.png">


