### PR TITLE
🐛 fix(HAT-356): 게시물 좋아요 수정

### DIFF
--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostService.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostService.java
@@ -114,6 +114,10 @@ public class ExternalPostService {
 
         Post getDetailPost = domainCommunityService.findById(postsId).orElseThrow(PostNotExistException::new);
 
+        int likeCount = (int)getDetailPost.getLikes().stream()
+            .filter(like -> like.getLiked())
+            .count();
+
         PostResponseDto.PostDto postDto = PostResponseDto.PostDto.builder()
             .postId(getDetailPost.getId())
             .region(getDetailPost.getRegion())
@@ -122,7 +126,11 @@ public class ExternalPostService {
             .memberImageUrl(getDetailPost.getMemberImage())
             .memberId(getDetailPost.getMemberId())
             .commentCount(getDetailPost.getComment().size())
-            .likeCount(getDetailPost.getLikes().size())
+            .likeCount(likeCount)
+            .likes(getDetailPost.getLikes().stream()
+                .map(like -> new PostResponseDto.LikeDto(
+                    like.getMemberId(), like.getLiked()
+                )).collect(Collectors.toList()))
             .memberNickname(getDetailPost.getMemberNickname())
             .content(getDetailPost.getContent())
             .deletedAt(getDetailPost.getDeletedAt())

--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/dto/response/PostResponseDto.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/dto/response/PostResponseDto.java
@@ -42,6 +42,8 @@ public class PostResponseDto {
         private int commentCount;
         private int likeCount;
 
+        private List<LikeDto> likes;
+
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
         private LocalDateTime deletedAt;
@@ -89,6 +91,16 @@ public class PostResponseDto {
         private String imageUrl;
 
 
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class LikeDto {
+
+        private UUID memberId;
+
+        private Boolean Liked;
     }
 }
 

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/Like.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/entity/Like.java
@@ -68,4 +68,8 @@ public class Like {
         return this;
     }
 
+    public boolean isLiked() {
+        return liked;
+    }
+
 }

--- a/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/querydsl/PostQslImpl.java
+++ b/community-domain-rds/src/main/java/io/howstheairtoday/communitydomainrds/querydsl/PostQslImpl.java
@@ -20,6 +20,7 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import io.howstheairtoday.communitydomainrds.entity.Like;
 import io.howstheairtoday.communitydomainrds.entity.Post;
 import io.howstheairtoday.communitydomainrds.entity.QComment;
 import io.howstheairtoday.communitydomainrds.entity.QLike;
@@ -79,7 +80,10 @@ public class PostQslImpl extends QuerydslRepositorySupport implements PostQslRep
                 resultMap.put("post", post);
                 resultMap.put("hasNext", hasNext && post.equals(postList.get(postList.size() - 1)));
                 resultMap.put("commentCount", post.getComment().size());
-                resultMap.put("likeCount", post.getLikes().size());
+                List<Like> likedLikes = post.getLikes().stream()
+                    .filter(Like::isLiked)
+                    .collect(Collectors.toList());
+                resultMap.put("likeCount", likedLikes.size());
                 return resultMap;
             })
             .collect(Collectors.toList());


### PR DESCRIPTION
## Motivation:

- 게시물 좋아요 수정

## Modifications:

- 좋아요 테이블에서 liked 컬럼이 true 일 때만 좋아요 개수를 count하도록 수정
  - 게시물 페이지 좋아요 수정
  - 게시물 상세 페이지 좋아요 수정

## Result:

- 좋아요가 true 일 때만 출력이 됨