### PR TITLE
👷 ci(HAT-383): 개발용 도커파일 추가

### DIFF
--- a/air-quality-app-batch/Dockerfile-dev
+++ b/air-quality-app-batch/Dockerfile-dev
@@ -5,12 +5,12 @@ FROM openjdk:17-alpine
 WORKDIR /app
 
 # 컨테이너 내부의 /app 디렉토리에 jar 파일 복사
-ARG JAR_FILE=community-app-external-api/build/libs/community-app-external-api-0.0.1-SNAPSHOT.jar
-ARG CONTAINER_JAR_FILE=community-app-external-api.jar
+ARG JAR_FILE=air-quality-app-batch/build/libs/air-quality-app-batch-0.0.1-SNAPSHOT.jar
+ARG CONTAINER_JAR_FILE=air-quality-app-batch.jar
 COPY ${JAR_FILE} ${CONTAINER_JAR_FILE}
 
 # Spring Boot를 실행하기 위한 entry point 지정
-ENTRYPOINT ["java", "-jar", "/app/community-app-external-api.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=hyyena", "-jar", "/app/air-quality-app-batch.jar"]
 
 # 시간 설정
 ENV TZ=Asia/Seoul

--- a/air-quality-app-external-api/Dockerfile-dev
+++ b/air-quality-app-external-api/Dockerfile-dev
@@ -5,12 +5,12 @@ FROM openjdk:17-alpine
 WORKDIR /app
 
 # 컨테이너 내부의 /app 디렉토리에 jar 파일 복사
-ARG JAR_FILE=member-app-external-api/build/libs/member-app-external-api-0.0.1-SNAPSHOT.jar
-ARG CONTAINER_JAR_FILE=member-app-external-api.jar
+ARG JAR_FILE=air-quality-app-external-api/build/libs/air-quality-app-external-api-0.0.1-SNAPSHOT.jar
+ARG CONTAINER_JAR_FILE=air-quality-app-external-api.jar
 COPY ${JAR_FILE} ${CONTAINER_JAR_FILE}
 
 # Spring Boot를 실행하기 위한 entry point 지정
-ENTRYPOINT ["java", "-jar", "/app/member-app-external-api.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=hyyena", "-jar", "/app/air-quality-app-external-api.jar"]
 
 # 시간 설정
 ENV TZ=Asia/Seoul

--- a/community-app-external-api/Dockerfile-dev
+++ b/community-app-external-api/Dockerfile-dev
@@ -5,12 +5,12 @@ FROM openjdk:17-alpine
 WORKDIR /app
 
 # 컨테이너 내부의 /app 디렉토리에 jar 파일 복사
-ARG JAR_FILE=air-quality-app-batch/build/libs/air-quality-app-batch-0.0.1-SNAPSHOT.jar
-ARG CONTAINER_JAR_FILE=air-quality-app-batch.jar
+ARG JAR_FILE=community-app-external-api/build/libs/community-app-external-api-0.0.1-SNAPSHOT.jar
+ARG CONTAINER_JAR_FILE=community-app-external-api.jar
 COPY ${JAR_FILE} ${CONTAINER_JAR_FILE}
 
 # Spring Boot를 실행하기 위한 entry point 지정
-ENTRYPOINT ["java", "-jar", "/app/air-quality-app-batch.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=hyyena", "-jar", "/app/community-app-external-api.jar"]
 
 # 시간 설정
 ENV TZ=Asia/Seoul

--- a/member-app-external-api/Dockerfile-dev
+++ b/member-app-external-api/Dockerfile-dev
@@ -5,12 +5,12 @@ FROM openjdk:17-alpine
 WORKDIR /app
 
 # 컨테이너 내부의 /app 디렉토리에 jar 파일 복사
-ARG JAR_FILE=air-quality-app-external-api/build/libs/air-quality-app-external-api-0.0.1-SNAPSHOT.jar
-ARG CONTAINER_JAR_FILE=air-quality-app-external-api.jar
+ARG JAR_FILE=member-app-external-api/build/libs/member-app-external-api-0.0.1-SNAPSHOT.jar
+ARG CONTAINER_JAR_FILE=member-app-external-api.jar
 COPY ${JAR_FILE} ${CONTAINER_JAR_FILE}
 
 # Spring Boot를 실행하기 위한 entry point 지정
-ENTRYPOINT ["java", "-jar", "/app/air-quality-app-external-api.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=hyyena", "-jar", "/app/member-app-external-api.jar"]
 
 # 시간 설정
 ENV TZ=Asia/Seoul


### PR DESCRIPTION
## Motivation:

- Spring Boot 프로필 별로 실행시킬 수 있게끔 `Dockerfile` 프로필 별 분리 필요

## Modifications:

- 아래와 같이 `ENTRYPOINT`에 프로필 활성화 명령어 추가
- `dev` 환경은 `hyyena` 프로필로 통일

```Dockerfile
ENTRYPOINT ["java", "-Dspring.profiles.active=hyyena", "-jar", "/app/member-app-external-api.jar"]
```

## Result:

- 도커 이미지 빌드

![스크린샷 2023-05-01 173144](https://user-images.githubusercontent.com/70932170/235430703-f62c2a73-eed0-4f30-a46b-2a3982240418.png)

- 도커 컨테이너 실행

![스크린샷 2023-05-01 173252](https://user-images.githubusercontent.com/70932170/235430721-604020f1-ffed-4a16-ab93-ba90179e5e5a.png)

- `hyyena` 프로필 활성화 확인

![image](https://user-images.githubusercontent.com/70932170/235430623-031293d7-65d8-4443-bf86-5aa12f0aa15b.png)
