### PR TITLE
🐛 fix(HAT-389): 게시물 상세보기 리턴값 수정

### DIFF
--- a/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostService.java
+++ b/community-app-external-api/src/main/java/io/howstheairtoday/appcommunityexternalapi/service/ExternalPostService.java
@@ -118,6 +118,10 @@ public class ExternalPostService {
             .filter(like -> like.getLiked())
             .count();
 
+        int Commentcount = (int)getDetailPost.getComment().stream()
+            .filter(comment -> comment.getDeletedAt() == null)
+            .count();
+
         PostResponseDto.PostDto postDto = PostResponseDto.PostDto.builder()
             .postId(getDetailPost.getId())
             .region(getDetailPost.getRegion())
@@ -125,7 +129,7 @@ public class ExternalPostService {
             .content(getDetailPost.getContent())
             .memberImageUrl(getDetailPost.getMemberImage())
             .memberId(getDetailPost.getMemberId())
-            .commentCount(getDetailPost.getComment().size())
+            .commentCount(Commentcount)
             .likeCount(likeCount)
             .likes(getDetailPost.getLikes().stream()
                 .map(like -> new PostResponseDto.LikeDto(


### PR DESCRIPTION
## Motivation:

- 게시물 상세보기 리턴값 수정

## Modifications:

- 마이페이지에서 게시물 상세볼 때 deletedAt이 null 값이 댓글들만 count
![image](https://user-images.githubusercontent.com/54580802/235490556-fe24f914-33e6-404b-af81-a11ef4fd4879.png)

## Result:

- 마이페이지 댓글 수
![image](https://user-images.githubusercontent.com/54580802/235490411-41d7a881-a129-47c8-8099-91afcd5da6f4.png)
